### PR TITLE
Oracle: merge Sprint B taste weighting + Sprint C reliability hardening

### DIFF
--- a/.agents/skills/supabase-postgres-best-practices/SKILL.md
+++ b/.agents/skills/supabase-postgres-best-practices/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: supabase-postgres-best-practices
+description: Postgres performance optimization and best practices from Supabase. Use this skill when writing, reviewing, or optimizing Postgres queries, schema designs, or database configurations.
+license: MIT
+metadata:
+  author: supabase
+  version: "1.1.1"
+  organization: Supabase
+  date: January 2026
+  abstract: Comprehensive Postgres performance optimization guide for developers using Supabase and Postgres. Contains performance rules across 8 categories, prioritized by impact from critical (query performance, connection management) to incremental (advanced features). Each rule includes detailed explanations, incorrect vs. correct SQL examples, query plan analysis, and specific performance metrics to guide automated optimization and code generation.
+---
+
+# Supabase Postgres Best Practices
+
+Comprehensive performance optimization guide for Postgres, maintained by Supabase. Contains rules across 8 categories, prioritized by impact to guide automated query optimization and schema design.
+
+## When to Apply
+
+Reference these guidelines when:
+- Writing SQL queries or designing schemas
+- Implementing indexes or query optimization
+- Reviewing database performance issues
+- Configuring connection pooling or scaling
+- Optimizing for Postgres-specific features
+- Working with Row-Level Security (RLS)
+
+## Rule Categories by Priority
+
+| Priority | Category | Impact | Prefix |
+|----------|----------|--------|--------|
+| 1 | Query Performance | CRITICAL | `query-` |
+| 2 | Connection Management | CRITICAL | `conn-` |
+| 3 | Security & RLS | CRITICAL | `security-` |
+| 4 | Schema Design | HIGH | `schema-` |
+| 5 | Concurrency & Locking | MEDIUM-HIGH | `lock-` |
+| 6 | Data Access Patterns | MEDIUM | `data-` |
+| 7 | Monitoring & Diagnostics | LOW-MEDIUM | `monitor-` |
+| 8 | Advanced Features | LOW | `advanced-` |
+
+## How to Use
+
+Read individual rule files for detailed explanations and SQL examples:
+
+```
+references/query-missing-indexes.md
+references/query-partial-indexes.md
+references/_sections.md
+```
+
+Each rule file contains:
+- Brief explanation of why it matters
+- Incorrect SQL example with explanation
+- Correct SQL example with explanation
+- Optional EXPLAIN output or metrics
+- Additional context and references
+- Supabase-specific notes (when applicable)
+
+## References
+
+- https://www.postgresql.org/docs/current/
+- https://supabase.com/docs
+- https://wiki.postgresql.org/wiki/Performance_Optimization
+- https://supabase.com/docs/guides/database/overview
+- https://supabase.com/docs/guides/auth/row-level-security

--- a/.agents/skills/supabase-postgres-best-practices/references/_contributing.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/_contributing.md
@@ -1,0 +1,170 @@
+# Writing Guidelines for Postgres References
+
+This document provides guidelines for creating effective Postgres best
+practice references that work well with AI agents and LLMs.
+
+## Key Principles
+
+### 1. Concrete Transformation Patterns
+
+Show exact SQL rewrites. Avoid philosophical advice.
+
+**Good:** "Use `WHERE id = ANY(ARRAY[...])` instead of
+`WHERE id IN (SELECT ...)`" **Bad:** "Design good schemas"
+
+### 2. Error-First Structure
+
+Always show the problematic pattern first, then the solution. This trains agents
+to recognize anti-patterns.
+
+```markdown
+**Incorrect (sequential queries):** [bad example]
+
+**Correct (batched query):** [good example]
+```
+
+### 3. Quantified Impact
+
+Include specific metrics. Helps agents prioritize fixes.
+
+**Good:** "10x faster queries", "50% smaller index", "Eliminates N+1" 
+**Bad:** "Faster", "Better", "More efficient"
+
+### 4. Self-Contained Examples
+
+Examples should be complete and runnable (or close to it). Include `CREATE TABLE`
+if context is needed.
+
+```sql
+-- Include table definition when needed for clarity
+CREATE TABLE users (
+  id bigint PRIMARY KEY,
+  email text NOT NULL,
+  deleted_at timestamptz
+);
+
+-- Now show the index
+CREATE INDEX users_active_email_idx ON users(email) WHERE deleted_at IS NULL;
+```
+
+### 5. Semantic Naming
+
+Use meaningful table/column names. Names carry intent for LLMs.
+
+**Good:** `users`, `email`, `created_at`, `is_active`
+**Bad:** `table1`, `col1`, `field`, `flag`
+
+---
+
+## Code Example Standards
+
+### SQL Formatting
+
+```sql
+-- Use lowercase keywords, clear formatting
+CREATE INDEX CONCURRENTLY users_email_idx
+  ON users(email)
+  WHERE deleted_at IS NULL;
+
+-- Not cramped or ALL CAPS
+CREATE INDEX CONCURRENTLY USERS_EMAIL_IDX ON USERS(EMAIL) WHERE DELETED_AT IS NULL;
+```
+
+### Comments
+
+- Explain _why_, not _what_
+- Highlight performance implications
+- Point out common pitfalls
+
+### Language Tags
+
+- `sql` - Standard SQL queries
+- `plpgsql` - Stored procedures/functions
+- `typescript` - Application code (when needed)
+- `python` - Application code (when needed)
+
+---
+
+## When to Include Application Code
+
+**Default: SQL Only**
+
+Most references should focus on pure SQL patterns. This keeps examples portable.
+
+**Include Application Code When:**
+
+- Connection pooling configuration
+- Transaction management in application context
+- ORM anti-patterns (N+1 in Prisma/TypeORM)
+- Prepared statement usage
+
+**Format for Mixed Examples:**
+
+````markdown
+**Incorrect (N+1 in application):**
+
+```typescript
+for (const user of users) {
+  const posts = await db.query("SELECT * FROM posts WHERE user_id = $1", [
+    user.id,
+  ]);
+}
+```
+````
+
+**Correct (batch query):**
+
+```typescript
+const posts = await db.query("SELECT * FROM posts WHERE user_id = ANY($1)", [
+  userIds,
+]);
+```
+
+---
+
+## Impact Level Guidelines
+
+| Level | Improvement | Use When |
+|-------|-------------|----------|
+| **CRITICAL** | 10-100x | Missing indexes, connection exhaustion, sequential scans on large tables |
+| **HIGH** | 5-20x | Wrong index types, poor partitioning, missing covering indexes |
+| **MEDIUM-HIGH** | 2-5x | N+1 queries, inefficient pagination, RLS optimization |
+| **MEDIUM** | 1.5-3x | Redundant indexes, query plan instability |
+| **LOW-MEDIUM** | 1.2-2x | VACUUM tuning, configuration tweaks |
+| **LOW** | Incremental | Advanced patterns, edge cases |
+
+---
+
+## Reference Standards
+
+**Primary Sources:**
+
+- Official Postgres documentation
+- Supabase documentation
+- Postgres wiki
+- Established blogs (2ndQuadrant, Crunchy Data)
+
+**Format:**
+
+```markdown
+Reference:
+[Postgres Indexes](https://www.postgresql.org/docs/current/indexes.html)
+```
+
+---
+
+## Review Checklist
+
+Before submitting a reference:
+
+- [ ] Title is clear and action-oriented
+- [ ] Impact level matches the performance gain
+- [ ] impactDescription includes quantification
+- [ ] Explanation is concise (1-2 sentences)
+- [ ] Has at least 1 **Incorrect** SQL example
+- [ ] Has at least 1 **Correct** SQL example
+- [ ] SQL uses semantic naming
+- [ ] Comments explain _why_, not _what_
+- [ ] Trade-offs mentioned if applicable
+- [ ] Reference links included
+- [ ] `pnpm test` passes

--- a/.agents/skills/supabase-postgres-best-practices/references/_sections.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/_sections.md
@@ -1,0 +1,39 @@
+# Section Definitions
+
+This file defines the rule categories for Postgres best practices. Rules are automatically assigned to sections based on their filename prefix.
+
+Take the examples below as pure demonstrative. Replace each section with the actual rule categories for Postgres best practices.
+
+---
+
+## 1. Query Performance (query)
+**Impact:** CRITICAL
+**Description:** Slow queries, missing indexes, inefficient query plans. The most common source of Postgres performance issues.
+
+## 2. Connection Management (conn)
+**Impact:** CRITICAL
+**Description:** Connection pooling, limits, and serverless strategies. Critical for applications with high concurrency or serverless deployments.
+
+## 3. Security & RLS (security)
+**Impact:** CRITICAL
+**Description:** Row-Level Security policies, privilege management, and authentication patterns.
+
+## 4. Schema Design (schema)
+**Impact:** HIGH
+**Description:** Table design, index strategies, partitioning, and data type selection. Foundation for long-term performance.
+
+## 5. Concurrency & Locking (lock)
+**Impact:** MEDIUM-HIGH
+**Description:** Transaction management, isolation levels, deadlock prevention, and lock contention patterns.
+
+## 6. Data Access Patterns (data)
+**Impact:** MEDIUM
+**Description:** N+1 query elimination, batch operations, cursor-based pagination, and efficient data fetching.
+
+## 7. Monitoring & Diagnostics (monitor)
+**Impact:** LOW-MEDIUM
+**Description:** Using pg_stat_statements, EXPLAIN ANALYZE, metrics collection, and performance diagnostics.
+
+## 8. Advanced Features (advanced)
+**Impact:** LOW
+**Description:** Full-text search, JSONB optimization, PostGIS, extensions, and advanced Postgres features.

--- a/.agents/skills/supabase-postgres-best-practices/references/_template.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/_template.md
@@ -1,0 +1,34 @@
+---
+title: Clear, Action-Oriented Title (e.g., "Use Partial Indexes for Filtered Queries")
+impact: MEDIUM
+impactDescription: 5-20x query speedup for filtered queries
+tags: indexes, query-optimization, performance
+---
+
+## [Rule Title]
+
+[1-2 sentence explanation of the problem and why it matters. Focus on performance impact.]
+
+**Incorrect (describe the problem):**
+
+```sql
+-- Comment explaining what makes this slow/problematic
+CREATE INDEX users_email_idx ON users(email);
+
+SELECT * FROM users WHERE email = 'user@example.com' AND deleted_at IS NULL;
+-- This scans deleted records unnecessarily
+```
+
+**Correct (describe the solution):**
+
+```sql
+-- Comment explaining why this is better
+CREATE INDEX users_active_email_idx ON users(email) WHERE deleted_at IS NULL;
+
+SELECT * FROM users WHERE email = 'user@example.com' AND deleted_at IS NULL;
+-- Only indexes active users, 10x smaller index, faster queries
+```
+
+[Optional: Additional context, edge cases, or trade-offs]
+
+Reference: [Postgres Docs](https://www.postgresql.org/docs/current/)

--- a/.agents/skills/supabase-postgres-best-practices/references/advanced-full-text-search.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/advanced-full-text-search.md
@@ -1,0 +1,55 @@
+---
+title: Use tsvector for Full-Text Search
+impact: MEDIUM
+impactDescription: 100x faster than LIKE, with ranking support
+tags: full-text-search, tsvector, gin, search
+---
+
+## Use tsvector for Full-Text Search
+
+LIKE with wildcards can't use indexes. Full-text search with tsvector is orders of magnitude faster.
+
+**Incorrect (LIKE pattern matching):**
+
+```sql
+-- Cannot use index, scans all rows
+select * from articles where content like '%postgresql%';
+
+-- Case-insensitive makes it worse
+select * from articles where lower(content) like '%postgresql%';
+```
+
+**Correct (full-text search with tsvector):**
+
+```sql
+-- Add tsvector column and index
+alter table articles add column search_vector tsvector
+  generated always as (to_tsvector('english', coalesce(title,'') || ' ' || coalesce(content,''))) stored;
+
+create index articles_search_idx on articles using gin (search_vector);
+
+-- Fast full-text search
+select * from articles
+where search_vector @@ to_tsquery('english', 'postgresql & performance');
+
+-- With ranking
+select *, ts_rank(search_vector, query) as rank
+from articles, to_tsquery('english', 'postgresql') query
+where search_vector @@ query
+order by rank desc;
+```
+
+Search multiple terms:
+
+```sql
+-- AND: both terms required
+to_tsquery('postgresql & performance')
+
+-- OR: either term
+to_tsquery('postgresql | mysql')
+
+-- Prefix matching
+to_tsquery('post:*')
+```
+
+Reference: [Full Text Search](https://supabase.com/docs/guides/database/full-text-search)

--- a/.agents/skills/supabase-postgres-best-practices/references/advanced-jsonb-indexing.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/advanced-jsonb-indexing.md
@@ -1,0 +1,49 @@
+---
+title: Index JSONB Columns for Efficient Querying
+impact: MEDIUM
+impactDescription: 10-100x faster JSONB queries with proper indexing
+tags: jsonb, gin, indexes, json
+---
+
+## Index JSONB Columns for Efficient Querying
+
+JSONB queries without indexes scan the entire table. Use GIN indexes for containment queries.
+
+**Incorrect (no index on JSONB):**
+
+```sql
+create table products (
+  id bigint primary key,
+  attributes jsonb
+);
+
+-- Full table scan for every query
+select * from products where attributes @> '{"color": "red"}';
+select * from products where attributes->>'brand' = 'Nike';
+```
+
+**Correct (GIN index for JSONB):**
+
+```sql
+-- GIN index for containment operators (@>, ?, ?&, ?|)
+create index products_attrs_gin on products using gin (attributes);
+
+-- Now containment queries use the index
+select * from products where attributes @> '{"color": "red"}';
+
+-- For specific key lookups, use expression index
+create index products_brand_idx on products ((attributes->>'brand'));
+select * from products where attributes->>'brand' = 'Nike';
+```
+
+Choose the right operator class:
+
+```sql
+-- jsonb_ops (default): supports all operators, larger index
+create index idx1 on products using gin (attributes);
+
+-- jsonb_path_ops: only @> operator, but 2-3x smaller index
+create index idx2 on products using gin (attributes jsonb_path_ops);
+```
+
+Reference: [JSONB Indexes](https://www.postgresql.org/docs/current/datatype-json.html#JSON-INDEXING)

--- a/.agents/skills/supabase-postgres-best-practices/references/conn-idle-timeout.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/conn-idle-timeout.md
@@ -1,0 +1,46 @@
+---
+title: Configure Idle Connection Timeouts
+impact: HIGH
+impactDescription: Reclaim 30-50% of connection slots from idle clients
+tags: connections, timeout, idle, resource-management
+---
+
+## Configure Idle Connection Timeouts
+
+Idle connections waste resources. Configure timeouts to automatically reclaim them.
+
+**Incorrect (connections held indefinitely):**
+
+```sql
+-- No timeout configured
+show idle_in_transaction_session_timeout;  -- 0 (disabled)
+
+-- Connections stay open forever, even when idle
+select pid, state, state_change, query
+from pg_stat_activity
+where state = 'idle in transaction';
+-- Shows transactions idle for hours, holding locks
+```
+
+**Correct (automatic cleanup of idle connections):**
+
+```sql
+-- Terminate connections idle in transaction after 30 seconds
+alter system set idle_in_transaction_session_timeout = '30s';
+
+-- Terminate completely idle connections after 10 minutes
+alter system set idle_session_timeout = '10min';
+
+-- Reload configuration
+select pg_reload_conf();
+```
+
+For pooled connections, configure at the pooler level:
+
+```ini
+# pgbouncer.ini
+server_idle_timeout = 60
+client_idle_timeout = 300
+```
+
+Reference: [Connection Timeouts](https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-IDLE-IN-TRANSACTION-SESSION-TIMEOUT)

--- a/.agents/skills/supabase-postgres-best-practices/references/conn-limits.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/conn-limits.md
@@ -1,0 +1,44 @@
+---
+title: Set Appropriate Connection Limits
+impact: CRITICAL
+impactDescription: Prevent database crashes and memory exhaustion
+tags: connections, max-connections, limits, stability
+---
+
+## Set Appropriate Connection Limits
+
+Too many connections exhaust memory and degrade performance. Set limits based on available resources.
+
+**Incorrect (unlimited or excessive connections):**
+
+```sql
+-- Default max_connections = 100, but often increased blindly
+show max_connections;  -- 500 (way too high for 4GB RAM)
+
+-- Each connection uses 1-3MB RAM
+-- 500 connections * 2MB = 1GB just for connections!
+-- Out of memory errors under load
+```
+
+**Correct (calculate based on resources):**
+
+```sql
+-- Formula: max_connections = (RAM in MB / 5MB per connection) - reserved
+-- For 4GB RAM: (4096 / 5) - 10 = ~800 theoretical max
+-- But practically, 100-200 is better for query performance
+
+-- Recommended settings for 4GB RAM
+alter system set max_connections = 100;
+
+-- Also set work_mem appropriately
+-- work_mem * max_connections should not exceed 25% of RAM
+alter system set work_mem = '8MB';  -- 8MB * 100 = 800MB max
+```
+
+Monitor connection usage:
+
+```sql
+select count(*), state from pg_stat_activity group by state;
+```
+
+Reference: [Database Connections](https://supabase.com/docs/guides/platform/performance#connection-management)

--- a/.agents/skills/supabase-postgres-best-practices/references/conn-pooling.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/conn-pooling.md
@@ -1,0 +1,41 @@
+---
+title: Use Connection Pooling for All Applications
+impact: CRITICAL
+impactDescription: Handle 10-100x more concurrent users
+tags: connection-pooling, pgbouncer, performance, scalability
+---
+
+## Use Connection Pooling for All Applications
+
+Postgres connections are expensive (1-3MB RAM each). Without pooling, applications exhaust connections under load.
+
+**Incorrect (new connection per request):**
+
+```sql
+-- Each request creates a new connection
+-- Application code: db.connect() per request
+-- Result: 500 concurrent users = 500 connections = crashed database
+
+-- Check current connections
+select count(*) from pg_stat_activity;  -- 487 connections!
+```
+
+**Correct (connection pooling):**
+
+```sql
+-- Use a pooler like PgBouncer between app and database
+-- Application connects to pooler, pooler reuses a small pool to Postgres
+
+-- Configure pool_size based on: (CPU cores * 2) + spindle_count
+-- Example for 4 cores: pool_size = 10
+
+-- Result: 500 concurrent users share 10 actual connections
+select count(*) from pg_stat_activity;  -- 10 connections
+```
+
+Pool modes:
+
+- **Transaction mode**: connection returned after each transaction (best for most apps)
+- **Session mode**: connection held for entire session (needed for prepared statements, temp tables)
+
+Reference: [Connection Pooling](https://supabase.com/docs/guides/database/connecting-to-postgres#connection-pooler)

--- a/.agents/skills/supabase-postgres-best-practices/references/conn-prepared-statements.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/conn-prepared-statements.md
@@ -1,0 +1,46 @@
+---
+title: Use Prepared Statements Correctly with Pooling
+impact: HIGH
+impactDescription: Avoid prepared statement conflicts in pooled environments
+tags: prepared-statements, connection-pooling, transaction-mode
+---
+
+## Use Prepared Statements Correctly with Pooling
+
+Prepared statements are tied to individual database connections. In transaction-mode pooling, connections are shared, causing conflicts.
+
+**Incorrect (named prepared statements with transaction pooling):**
+
+```sql
+-- Named prepared statement
+prepare get_user as select * from users where id = $1;
+
+-- In transaction mode pooling, next request may get different connection
+execute get_user(123);
+-- ERROR: prepared statement "get_user" does not exist
+```
+
+**Correct (use unnamed statements or session mode):**
+
+```sql
+-- Option 1: Use unnamed prepared statements (most ORMs do this automatically)
+-- The query is prepared and executed in a single protocol message
+
+-- Option 2: Deallocate after use in transaction mode
+prepare get_user as select * from users where id = $1;
+execute get_user(123);
+deallocate get_user;
+
+-- Option 3: Use session mode pooling (port 5432 vs 6543)
+-- Connection is held for entire session, prepared statements persist
+```
+
+Check your driver settings:
+
+```sql
+-- Many drivers use prepared statements by default
+-- Node.js pg: { prepare: false } to disable
+-- JDBC: prepareThreshold=0 to disable
+```
+
+Reference: [Prepared Statements with Pooling](https://supabase.com/docs/guides/database/connecting-to-postgres#connection-pool-modes)

--- a/.agents/skills/supabase-postgres-best-practices/references/data-batch-inserts.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/data-batch-inserts.md
@@ -1,0 +1,54 @@
+---
+title: Batch INSERT Statements for Bulk Data
+impact: MEDIUM
+impactDescription: 10-50x faster bulk inserts
+tags: batch, insert, bulk, performance, copy
+---
+
+## Batch INSERT Statements for Bulk Data
+
+Individual INSERT statements have high overhead. Batch multiple rows in single statements or use COPY.
+
+**Incorrect (individual inserts):**
+
+```sql
+-- Each insert is a separate transaction and round trip
+insert into events (user_id, action) values (1, 'click');
+insert into events (user_id, action) values (1, 'view');
+insert into events (user_id, action) values (2, 'click');
+-- ... 1000 more individual inserts
+
+-- 1000 inserts = 1000 round trips = slow
+```
+
+**Correct (batch insert):**
+
+```sql
+-- Multiple rows in single statement
+insert into events (user_id, action) values
+  (1, 'click'),
+  (1, 'view'),
+  (2, 'click'),
+  -- ... up to ~1000 rows per batch
+  (999, 'view');
+
+-- One round trip for 1000 rows
+```
+
+For large imports, use COPY:
+
+```sql
+-- COPY is fastest for bulk loading
+copy events (user_id, action, created_at)
+from '/path/to/data.csv'
+with (format csv, header true);
+
+-- Or from stdin in application
+copy events (user_id, action) from stdin with (format csv);
+1,click
+1,view
+2,click
+\.
+```
+
+Reference: [COPY](https://www.postgresql.org/docs/current/sql-copy.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/data-n-plus-one.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/data-n-plus-one.md
@@ -1,0 +1,53 @@
+---
+title: Eliminate N+1 Queries with Batch Loading
+impact: MEDIUM-HIGH
+impactDescription: 10-100x fewer database round trips
+tags: n-plus-one, batch, performance, queries
+---
+
+## Eliminate N+1 Queries with Batch Loading
+
+N+1 queries execute one query per item in a loop. Batch them into a single query using arrays or JOINs.
+
+**Incorrect (N+1 queries):**
+
+```sql
+-- First query: get all users
+select id from users where active = true;  -- Returns 100 IDs
+
+-- Then N queries, one per user
+select * from orders where user_id = 1;
+select * from orders where user_id = 2;
+select * from orders where user_id = 3;
+-- ... 97 more queries!
+
+-- Total: 101 round trips to database
+```
+
+**Correct (single batch query):**
+
+```sql
+-- Collect IDs and query once with ANY
+select * from orders where user_id = any(array[1, 2, 3, ...]);
+
+-- Or use JOIN instead of loop
+select u.id, u.name, o.*
+from users u
+left join orders o on o.user_id = u.id
+where u.active = true;
+
+-- Total: 1 round trip
+```
+
+Application pattern:
+
+```sql
+-- Instead of looping in application code:
+-- for user in users: db.query("SELECT * FROM orders WHERE user_id = $1", user.id)
+
+-- Pass array parameter:
+select * from orders where user_id = any($1::bigint[]);
+-- Application passes: [1, 2, 3, 4, 5, ...]
+```
+
+Reference: [N+1 Query Problem](https://supabase.com/docs/guides/database/query-optimization)

--- a/.agents/skills/supabase-postgres-best-practices/references/data-pagination.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/data-pagination.md
@@ -1,0 +1,50 @@
+---
+title: Use Cursor-Based Pagination Instead of OFFSET
+impact: MEDIUM-HIGH
+impactDescription: Consistent O(1) performance regardless of page depth
+tags: pagination, cursor, keyset, offset, performance
+---
+
+## Use Cursor-Based Pagination Instead of OFFSET
+
+OFFSET-based pagination scans all skipped rows, getting slower on deeper pages. Cursor pagination is O(1).
+
+**Incorrect (OFFSET pagination):**
+
+```sql
+-- Page 1: scans 20 rows
+select * from products order by id limit 20 offset 0;
+
+-- Page 100: scans 2000 rows to skip 1980
+select * from products order by id limit 20 offset 1980;
+
+-- Page 10000: scans 200,000 rows!
+select * from products order by id limit 20 offset 199980;
+```
+
+**Correct (cursor/keyset pagination):**
+
+```sql
+-- Page 1: get first 20
+select * from products order by id limit 20;
+-- Application stores last_id = 20
+
+-- Page 2: start after last ID
+select * from products where id > 20 order by id limit 20;
+-- Uses index, always fast regardless of page depth
+
+-- Page 10000: same speed as page 1
+select * from products where id > 199980 order by id limit 20;
+```
+
+For multi-column sorting:
+
+```sql
+-- Cursor must include all sort columns
+select * from products
+where (created_at, id) > ('2024-01-15 10:00:00', 12345)
+order by created_at, id
+limit 20;
+```
+
+Reference: [Pagination](https://supabase.com/docs/guides/database/pagination)

--- a/.agents/skills/supabase-postgres-best-practices/references/data-upsert.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/data-upsert.md
@@ -1,0 +1,50 @@
+---
+title: Use UPSERT for Insert-or-Update Operations
+impact: MEDIUM
+impactDescription: Atomic operation, eliminates race conditions
+tags: upsert, on-conflict, insert, update
+---
+
+## Use UPSERT for Insert-or-Update Operations
+
+Using separate SELECT-then-INSERT/UPDATE creates race conditions. Use INSERT ... ON CONFLICT for atomic upserts.
+
+**Incorrect (check-then-insert race condition):**
+
+```sql
+-- Race condition: two requests check simultaneously
+select * from settings where user_id = 123 and key = 'theme';
+-- Both find nothing
+
+-- Both try to insert
+insert into settings (user_id, key, value) values (123, 'theme', 'dark');
+-- One succeeds, one fails with duplicate key error!
+```
+
+**Correct (atomic UPSERT):**
+
+```sql
+-- Single atomic operation
+insert into settings (user_id, key, value)
+values (123, 'theme', 'dark')
+on conflict (user_id, key)
+do update set value = excluded.value, updated_at = now();
+
+-- Returns the inserted/updated row
+insert into settings (user_id, key, value)
+values (123, 'theme', 'dark')
+on conflict (user_id, key)
+do update set value = excluded.value
+returning *;
+```
+
+Insert-or-ignore pattern:
+
+```sql
+-- Insert only if not exists (no update)
+insert into page_views (page_id, user_id)
+values (1, 123)
+on conflict (page_id, user_id) do nothing;
+```
+
+Reference: [INSERT ON CONFLICT](https://www.postgresql.org/docs/current/sql-insert.html#SQL-ON-CONFLICT)

--- a/.agents/skills/supabase-postgres-best-practices/references/lock-advisory.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/lock-advisory.md
@@ -1,0 +1,56 @@
+---
+title: Use Advisory Locks for Application-Level Locking
+impact: MEDIUM
+impactDescription: Efficient coordination without row-level lock overhead
+tags: advisory-locks, coordination, application-locks
+---
+
+## Use Advisory Locks for Application-Level Locking
+
+Advisory locks provide application-level coordination without requiring database rows to lock.
+
+**Incorrect (creating rows just for locking):**
+
+```sql
+-- Creating dummy rows to lock on
+create table resource_locks (
+  resource_name text primary key
+);
+
+insert into resource_locks values ('report_generator');
+
+-- Lock by selecting the row
+select * from resource_locks where resource_name = 'report_generator' for update;
+```
+
+**Correct (advisory locks):**
+
+```sql
+-- Session-level advisory lock (released on disconnect or unlock)
+select pg_advisory_lock(hashtext('report_generator'));
+-- ... do exclusive work ...
+select pg_advisory_unlock(hashtext('report_generator'));
+
+-- Transaction-level lock (released on commit/rollback)
+begin;
+select pg_advisory_xact_lock(hashtext('daily_report'));
+-- ... do work ...
+commit;  -- Lock automatically released
+```
+
+Try-lock for non-blocking operations:
+
+```sql
+-- Returns immediately with true/false instead of waiting
+select pg_try_advisory_lock(hashtext('resource_name'));
+
+-- Use in application
+if (acquired) {
+  -- Do work
+  select pg_advisory_unlock(hashtext('resource_name'));
+} else {
+  -- Skip or retry later
+}
+```
+
+Reference: [Advisory Locks](https://www.postgresql.org/docs/current/explicit-locking.html#ADVISORY-LOCKS)

--- a/.agents/skills/supabase-postgres-best-practices/references/lock-deadlock-prevention.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/lock-deadlock-prevention.md
@@ -1,0 +1,68 @@
+---
+title: Prevent Deadlocks with Consistent Lock Ordering
+impact: MEDIUM-HIGH
+impactDescription: Eliminate deadlock errors, improve reliability
+tags: deadlocks, locking, transactions, ordering
+---
+
+## Prevent Deadlocks with Consistent Lock Ordering
+
+Deadlocks occur when transactions lock resources in different orders. Always
+acquire locks in a consistent order.
+
+**Incorrect (inconsistent lock ordering):**
+
+```sql
+-- Transaction A                    -- Transaction B
+begin;                              begin;
+update accounts                     update accounts
+set balance = balance - 100         set balance = balance - 50
+where id = 1;                       where id = 2;  -- B locks row 2
+
+update accounts                     update accounts
+set balance = balance + 100         set balance = balance + 50
+where id = 2;  -- A waits for B     where id = 1;  -- B waits for A
+
+-- DEADLOCK! Both waiting for each other
+```
+
+**Correct (lock rows in consistent order first):**
+
+```sql
+-- Explicitly acquire locks in ID order before updating
+begin;
+select * from accounts where id in (1, 2) order by id for update;
+
+-- Now perform updates in any order - locks already held
+update accounts set balance = balance - 100 where id = 1;
+update accounts set balance = balance + 100 where id = 2;
+commit;
+```
+
+Alternative: use a single statement to update atomically:
+
+```sql
+-- Single statement acquires all locks atomically
+begin;
+update accounts
+set balance = balance + case id
+  when 1 then -100
+  when 2 then 100
+end
+where id in (1, 2);
+commit;
+```
+
+Detect deadlocks in logs:
+
+```sql
+-- Check for recent deadlocks
+select * from pg_stat_database where deadlocks > 0;
+
+-- Enable deadlock logging
+set log_lock_waits = on;
+set deadlock_timeout = '1s';
+```
+
+Reference:
+[Deadlocks](https://www.postgresql.org/docs/current/explicit-locking.html#LOCKING-DEADLOCKS)

--- a/.agents/skills/supabase-postgres-best-practices/references/lock-short-transactions.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/lock-short-transactions.md
@@ -1,0 +1,50 @@
+---
+title: Keep Transactions Short to Reduce Lock Contention
+impact: MEDIUM-HIGH
+impactDescription: 3-5x throughput improvement, fewer deadlocks
+tags: transactions, locking, contention, performance
+---
+
+## Keep Transactions Short to Reduce Lock Contention
+
+Long-running transactions hold locks that block other queries. Keep transactions as short as possible.
+
+**Incorrect (long transaction with external calls):**
+
+```sql
+begin;
+select * from orders where id = 1 for update;  -- Lock acquired
+
+-- Application makes HTTP call to payment API (2-5 seconds)
+-- Other queries on this row are blocked!
+
+update orders set status = 'paid' where id = 1;
+commit;  -- Lock held for entire duration
+```
+
+**Correct (minimal transaction scope):**
+
+```sql
+-- Validate data and call APIs outside transaction
+-- Application: response = await paymentAPI.charge(...)
+
+-- Only hold lock for the actual update
+begin;
+update orders
+set status = 'paid', payment_id = $1
+where id = $2 and status = 'pending'
+returning *;
+commit;  -- Lock held for milliseconds
+```
+
+Use `statement_timeout` to prevent runaway transactions:
+
+```sql
+-- Abort queries running longer than 30 seconds
+set statement_timeout = '30s';
+
+-- Or per-session
+set local statement_timeout = '5s';
+```
+
+Reference: [Transaction Management](https://www.postgresql.org/docs/current/tutorial-transactions.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/lock-skip-locked.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/lock-skip-locked.md
@@ -1,0 +1,54 @@
+---
+title: Use SKIP LOCKED for Non-Blocking Queue Processing
+impact: MEDIUM-HIGH
+impactDescription: 10x throughput for worker queues
+tags: skip-locked, queue, workers, concurrency
+---
+
+## Use SKIP LOCKED for Non-Blocking Queue Processing
+
+When multiple workers process a queue, SKIP LOCKED allows workers to process different rows without waiting.
+
+**Incorrect (workers block each other):**
+
+```sql
+-- Worker 1 and Worker 2 both try to get next job
+begin;
+select * from jobs where status = 'pending' order by created_at limit 1 for update;
+-- Worker 2 waits for Worker 1's lock to release!
+```
+
+**Correct (SKIP LOCKED for parallel processing):**
+
+```sql
+-- Each worker skips locked rows and gets the next available
+begin;
+select * from jobs
+where status = 'pending'
+order by created_at
+limit 1
+for update skip locked;
+
+-- Worker 1 gets job 1, Worker 2 gets job 2 (no waiting)
+
+update jobs set status = 'processing' where id = $1;
+commit;
+```
+
+Complete queue pattern:
+
+```sql
+-- Atomic claim-and-update in one statement
+update jobs
+set status = 'processing', worker_id = $1, started_at = now()
+where id = (
+  select id from jobs
+  where status = 'pending'
+  order by created_at
+  limit 1
+  for update skip locked
+)
+returning *;
+```
+
+Reference: [SELECT FOR UPDATE SKIP LOCKED](https://www.postgresql.org/docs/current/sql-select.html#SQL-FOR-UPDATE-SHARE)

--- a/.agents/skills/supabase-postgres-best-practices/references/monitor-explain-analyze.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/monitor-explain-analyze.md
@@ -1,0 +1,45 @@
+---
+title: Use EXPLAIN ANALYZE to Diagnose Slow Queries
+impact: LOW-MEDIUM
+impactDescription: Identify exact bottlenecks in query execution
+tags: explain, analyze, diagnostics, query-plan
+---
+
+## Use EXPLAIN ANALYZE to Diagnose Slow Queries
+
+EXPLAIN ANALYZE executes the query and shows actual timings, revealing the true performance bottlenecks.
+
+**Incorrect (guessing at performance issues):**
+
+```sql
+-- Query is slow, but why?
+select * from orders where customer_id = 123 and status = 'pending';
+-- "It must be missing an index" - but which one?
+```
+
+**Correct (use EXPLAIN ANALYZE):**
+
+```sql
+explain (analyze, buffers, format text)
+select * from orders where customer_id = 123 and status = 'pending';
+
+-- Output reveals the issue:
+-- Seq Scan on orders (cost=0.00..25000.00 rows=50 width=100) (actual time=0.015..450.123 rows=50 loops=1)
+--   Filter: ((customer_id = 123) AND (status = 'pending'::text))
+--   Rows Removed by Filter: 999950
+--   Buffers: shared hit=5000 read=15000
+-- Planning Time: 0.150 ms
+-- Execution Time: 450.500 ms
+```
+
+Key things to look for:
+
+```sql
+-- Seq Scan on large tables = missing index
+-- Rows Removed by Filter = poor selectivity or missing index
+-- Buffers: read >> hit = data not cached, needs more memory
+-- Nested Loop with high loops = consider different join strategy
+-- Sort Method: external merge = work_mem too low
+```
+
+Reference: [EXPLAIN](https://supabase.com/docs/guides/database/inspect)

--- a/.agents/skills/supabase-postgres-best-practices/references/monitor-pg-stat-statements.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/monitor-pg-stat-statements.md
@@ -1,0 +1,55 @@
+---
+title: Enable pg_stat_statements for Query Analysis
+impact: LOW-MEDIUM
+impactDescription: Identify top resource-consuming queries
+tags: pg-stat-statements, monitoring, statistics, performance
+---
+
+## Enable pg_stat_statements for Query Analysis
+
+pg_stat_statements tracks execution statistics for all queries, helping identify slow and frequent queries.
+
+**Incorrect (no visibility into query patterns):**
+
+```sql
+-- Database is slow, but which queries are the problem?
+-- No way to know without pg_stat_statements
+```
+
+**Correct (enable and query pg_stat_statements):**
+
+```sql
+-- Enable the extension
+create extension if not exists pg_stat_statements;
+
+-- Find slowest queries by total time
+select
+  calls,
+  round(total_exec_time::numeric, 2) as total_time_ms,
+  round(mean_exec_time::numeric, 2) as mean_time_ms,
+  query
+from pg_stat_statements
+order by total_exec_time desc
+limit 10;
+
+-- Find most frequent queries
+select calls, query
+from pg_stat_statements
+order by calls desc
+limit 10;
+
+-- Reset statistics after optimization
+select pg_stat_statements_reset();
+```
+
+Key metrics to monitor:
+
+```sql
+-- Queries with high mean time (candidates for optimization)
+select query, mean_exec_time, calls
+from pg_stat_statements
+where mean_exec_time > 100  -- > 100ms average
+order by mean_exec_time desc;
+```
+
+Reference: [pg_stat_statements](https://supabase.com/docs/guides/database/extensions/pg_stat_statements)

--- a/.agents/skills/supabase-postgres-best-practices/references/monitor-vacuum-analyze.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/monitor-vacuum-analyze.md
@@ -1,0 +1,55 @@
+---
+title: Maintain Table Statistics with VACUUM and ANALYZE
+impact: MEDIUM
+impactDescription: 2-10x better query plans with accurate statistics
+tags: vacuum, analyze, statistics, maintenance, autovacuum
+---
+
+## Maintain Table Statistics with VACUUM and ANALYZE
+
+Outdated statistics cause the query planner to make poor decisions. VACUUM reclaims space, ANALYZE updates statistics.
+
+**Incorrect (stale statistics):**
+
+```sql
+-- Table has 1M rows but stats say 1000
+-- Query planner chooses wrong strategy
+explain select * from orders where status = 'pending';
+-- Shows: Seq Scan (because stats show small table)
+-- Actually: Index Scan would be much faster
+```
+
+**Correct (maintain fresh statistics):**
+
+```sql
+-- Manually analyze after large data changes
+analyze orders;
+
+-- Analyze specific columns used in WHERE clauses
+analyze orders (status, created_at);
+
+-- Check when tables were last analyzed
+select
+  relname,
+  last_vacuum,
+  last_autovacuum,
+  last_analyze,
+  last_autoanalyze
+from pg_stat_user_tables
+order by last_analyze nulls first;
+```
+
+Autovacuum tuning for busy tables:
+
+```sql
+-- Increase frequency for high-churn tables
+alter table orders set (
+  autovacuum_vacuum_scale_factor = 0.05,     -- Vacuum at 5% dead tuples (default 20%)
+  autovacuum_analyze_scale_factor = 0.02     -- Analyze at 2% changes (default 10%)
+);
+
+-- Check autovacuum status
+select * from pg_stat_progress_vacuum;
+```
+
+Reference: [VACUUM](https://supabase.com/docs/guides/database/database-size#vacuum-operations)

--- a/.agents/skills/supabase-postgres-best-practices/references/query-composite-indexes.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/query-composite-indexes.md
@@ -1,0 +1,44 @@
+---
+title: Create Composite Indexes for Multi-Column Queries
+impact: HIGH
+impactDescription: 5-10x faster multi-column queries
+tags: indexes, composite-index, multi-column, query-optimization
+---
+
+## Create Composite Indexes for Multi-Column Queries
+
+When queries filter on multiple columns, a composite index is more efficient than separate single-column indexes.
+
+**Incorrect (separate indexes require bitmap scan):**
+
+```sql
+-- Two separate indexes
+create index orders_status_idx on orders (status);
+create index orders_created_idx on orders (created_at);
+
+-- Query must combine both indexes (slower)
+select * from orders where status = 'pending' and created_at > '2024-01-01';
+```
+
+**Correct (composite index):**
+
+```sql
+-- Single composite index (leftmost column first for equality checks)
+create index orders_status_created_idx on orders (status, created_at);
+
+-- Query uses one efficient index scan
+select * from orders where status = 'pending' and created_at > '2024-01-01';
+```
+
+**Column order matters** - place equality columns first, range columns last:
+
+```sql
+-- Good: status (=) before created_at (>)
+create index idx on orders (status, created_at);
+
+-- Works for: WHERE status = 'pending'
+-- Works for: WHERE status = 'pending' AND created_at > '2024-01-01'
+-- Does NOT work for: WHERE created_at > '2024-01-01' (leftmost prefix rule)
+```
+
+Reference: [Multicolumn Indexes](https://www.postgresql.org/docs/current/indexes-multicolumn.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/query-covering-indexes.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/query-covering-indexes.md
@@ -1,0 +1,40 @@
+---
+title: Use Covering Indexes to Avoid Table Lookups
+impact: MEDIUM-HIGH
+impactDescription: 2-5x faster queries by eliminating heap fetches
+tags: indexes, covering-index, include, index-only-scan
+---
+
+## Use Covering Indexes to Avoid Table Lookups
+
+Covering indexes include all columns needed by a query, enabling index-only scans that skip the table entirely.
+
+**Incorrect (index scan + heap fetch):**
+
+```sql
+create index users_email_idx on users (email);
+
+-- Must fetch name and created_at from table heap
+select email, name, created_at from users where email = 'user@example.com';
+```
+
+**Correct (index-only scan with INCLUDE):**
+
+```sql
+-- Include non-searchable columns in the index
+create index users_email_idx on users (email) include (name, created_at);
+
+-- All columns served from index, no table access needed
+select email, name, created_at from users where email = 'user@example.com';
+```
+
+Use INCLUDE for columns you SELECT but don't filter on:
+
+```sql
+-- Searching by status, but also need customer_id and total
+create index orders_status_idx on orders (status) include (customer_id, total);
+
+select status, customer_id, total from orders where status = 'shipped';
+```
+
+Reference: [Index-Only Scans](https://www.postgresql.org/docs/current/indexes-index-only-scans.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/query-index-types.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/query-index-types.md
@@ -1,0 +1,48 @@
+---
+title: Choose the Right Index Type for Your Data
+impact: HIGH
+impactDescription: 10-100x improvement with correct index type
+tags: indexes, btree, gin, gist, brin, hash, index-types
+---
+
+## Choose the Right Index Type for Your Data
+
+Different index types excel at different query patterns. The default B-tree isn't always optimal.
+
+**Incorrect (B-tree for JSONB containment):**
+
+```sql
+-- B-tree cannot optimize containment operators
+create index products_attrs_idx on products (attributes);
+select * from products where attributes @> '{"color": "red"}';
+-- Full table scan - B-tree doesn't support @> operator
+```
+
+**Correct (GIN for JSONB):**
+
+```sql
+-- GIN supports @>, ?, ?&, ?| operators
+create index products_attrs_idx on products using gin (attributes);
+select * from products where attributes @> '{"color": "red"}';
+```
+
+Index type guide:
+
+```sql
+-- B-tree (default): =, <, >, BETWEEN, IN, IS NULL
+create index users_created_idx on users (created_at);
+
+-- GIN: arrays, JSONB, full-text search
+create index posts_tags_idx on posts using gin (tags);
+
+-- GiST: geometric data, range types, nearest-neighbor (KNN) queries
+create index locations_idx on places using gist (location);
+
+-- BRIN: large time-series tables (10-100x smaller)
+create index events_time_idx on events using brin (created_at);
+
+-- Hash: equality-only (slightly faster than B-tree for =)
+create index sessions_token_idx on sessions using hash (token);
+```
+
+Reference: [Index Types](https://www.postgresql.org/docs/current/indexes-types.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/query-missing-indexes.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/query-missing-indexes.md
@@ -1,0 +1,43 @@
+---
+title: Add Indexes on WHERE and JOIN Columns
+impact: CRITICAL
+impactDescription: 100-1000x faster queries on large tables
+tags: indexes, performance, sequential-scan, query-optimization
+---
+
+## Add Indexes on WHERE and JOIN Columns
+
+Queries filtering or joining on unindexed columns cause full table scans, which become exponentially slower as tables grow.
+
+**Incorrect (sequential scan on large table):**
+
+```sql
+-- No index on customer_id causes full table scan
+select * from orders where customer_id = 123;
+
+-- EXPLAIN shows: Seq Scan on orders (cost=0.00..25000.00 rows=100 width=85)
+```
+
+**Correct (index scan):**
+
+```sql
+-- Create index on frequently filtered column
+create index orders_customer_id_idx on orders (customer_id);
+
+select * from orders where customer_id = 123;
+
+-- EXPLAIN shows: Index Scan using orders_customer_id_idx (cost=0.42..8.44 rows=100 width=85)
+```
+
+For JOIN columns, always index the foreign key side:
+
+```sql
+-- Index the referencing column
+create index orders_customer_id_idx on orders (customer_id);
+
+select c.name, o.total
+from customers c
+join orders o on o.customer_id = c.id;
+```
+
+Reference: [Query Optimization](https://supabase.com/docs/guides/database/query-optimization)

--- a/.agents/skills/supabase-postgres-best-practices/references/query-partial-indexes.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/query-partial-indexes.md
@@ -1,0 +1,45 @@
+---
+title: Use Partial Indexes for Filtered Queries
+impact: HIGH
+impactDescription: 5-20x smaller indexes, faster writes and queries
+tags: indexes, partial-index, query-optimization, storage
+---
+
+## Use Partial Indexes for Filtered Queries
+
+Partial indexes only include rows matching a WHERE condition, making them smaller and faster when queries consistently filter on the same condition.
+
+**Incorrect (full index includes irrelevant rows):**
+
+```sql
+-- Index includes all rows, even soft-deleted ones
+create index users_email_idx on users (email);
+
+-- Query always filters active users
+select * from users where email = 'user@example.com' and deleted_at is null;
+```
+
+**Correct (partial index matches query filter):**
+
+```sql
+-- Index only includes active users
+create index users_active_email_idx on users (email)
+where deleted_at is null;
+
+-- Query uses the smaller, faster index
+select * from users where email = 'user@example.com' and deleted_at is null;
+```
+
+Common use cases for partial indexes:
+
+```sql
+-- Only pending orders (status rarely changes once completed)
+create index orders_pending_idx on orders (created_at)
+where status = 'pending';
+
+-- Only non-null values
+create index products_sku_idx on products (sku)
+where sku is not null;
+```
+
+Reference: [Partial Indexes](https://www.postgresql.org/docs/current/indexes-partial.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/schema-constraints.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/schema-constraints.md
@@ -1,0 +1,80 @@
+---
+title: Add Constraints Safely in Migrations
+impact: HIGH
+impactDescription: Prevents migration failures and enables idempotent schema changes
+tags: constraints, migrations, schema, alter-table
+---
+
+## Add Constraints Safely in Migrations
+
+PostgreSQL does not support `ADD CONSTRAINT IF NOT EXISTS`. Migrations using this syntax will fail.
+
+**Incorrect (causes syntax error):**
+
+```sql
+-- ERROR: syntax error at or near "not" (SQLSTATE 42601)
+alter table public.profiles
+add constraint if not exists profiles_birthchart_id_unique unique (birthchart_id);
+```
+
+**Correct (idempotent constraint creation):**
+
+```sql
+-- Use DO block to check before adding
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'profiles_birthchart_id_unique'
+    and conrelid = 'public.profiles'::regclass
+  ) then
+    alter table public.profiles
+    add constraint profiles_birthchart_id_unique unique (birthchart_id);
+  end if;
+end $$;
+```
+
+For all constraint types:
+
+```sql
+-- Check constraints
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'check_age_positive'
+  ) then
+    alter table users add constraint check_age_positive check (age > 0);
+  end if;
+end $$;
+
+-- Foreign keys
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'profiles_birthchart_id_fkey'
+  ) then
+    alter table profiles
+    add constraint profiles_birthchart_id_fkey
+    foreign key (birthchart_id) references birthcharts(id);
+  end if;
+end $$;
+```
+
+Check if constraint exists:
+
+```sql
+-- Query to check constraint existence
+select conname, contype, pg_get_constraintdef(oid)
+from pg_constraint
+where conrelid = 'public.profiles'::regclass;
+
+-- contype values:
+-- 'p' = PRIMARY KEY
+-- 'f' = FOREIGN KEY
+-- 'u' = UNIQUE
+-- 'c' = CHECK
+```
+
+Reference: [Constraints](https://www.postgresql.org/docs/current/ddl-constraints.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/schema-data-types.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/schema-data-types.md
@@ -1,0 +1,46 @@
+---
+title: Choose Appropriate Data Types
+impact: HIGH
+impactDescription: 50% storage reduction, faster comparisons
+tags: data-types, schema, storage, performance
+---
+
+## Choose Appropriate Data Types
+
+Using the right data types reduces storage, improves query performance, and prevents bugs.
+
+**Incorrect (wrong data types):**
+
+```sql
+create table users (
+  id int,                    -- Will overflow at 2.1 billion
+  email varchar(255),        -- Unnecessary length limit
+  created_at timestamp,      -- Missing timezone info
+  is_active varchar(5),      -- String for boolean
+  price varchar(20)          -- String for numeric
+);
+```
+
+**Correct (appropriate data types):**
+
+```sql
+create table users (
+  id bigint generated always as identity primary key,  -- 9 quintillion max
+  email text,                     -- No artificial limit, same performance as varchar
+  created_at timestamptz,         -- Always store timezone-aware timestamps
+  is_active boolean default true, -- 1 byte vs variable string length
+  price numeric(10,2)             -- Exact decimal arithmetic
+);
+```
+
+Key guidelines:
+
+```sql
+-- IDs: use bigint, not int (future-proofing)
+-- Strings: use text, not varchar(n) unless constraint needed
+-- Time: use timestamptz, not timestamp
+-- Money: use numeric, not float (precision matters)
+-- Enums: use text with check constraint or create enum type
+```
+
+Reference: [Data Types](https://www.postgresql.org/docs/current/datatype.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/schema-foreign-key-indexes.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/schema-foreign-key-indexes.md
@@ -1,0 +1,59 @@
+---
+title: Index Foreign Key Columns
+impact: HIGH
+impactDescription: 10-100x faster JOINs and CASCADE operations
+tags: foreign-key, indexes, joins, schema
+---
+
+## Index Foreign Key Columns
+
+Postgres does not automatically index foreign key columns. Missing indexes cause slow JOINs and CASCADE operations.
+
+**Incorrect (unindexed foreign key):**
+
+```sql
+create table orders (
+  id bigint generated always as identity primary key,
+  customer_id bigint references customers(id) on delete cascade,
+  total numeric(10,2)
+);
+
+-- No index on customer_id!
+-- JOINs and ON DELETE CASCADE both require full table scan
+select * from orders where customer_id = 123;  -- Seq Scan
+delete from customers where id = 123;          -- Locks table, scans all orders
+```
+
+**Correct (indexed foreign key):**
+
+```sql
+create table orders (
+  id bigint generated always as identity primary key,
+  customer_id bigint references customers(id) on delete cascade,
+  total numeric(10,2)
+);
+
+-- Always index the FK column
+create index orders_customer_id_idx on orders (customer_id);
+
+-- Now JOINs and cascades are fast
+select * from orders where customer_id = 123;  -- Index Scan
+delete from customers where id = 123;          -- Uses index, fast cascade
+```
+
+Find missing FK indexes:
+
+```sql
+select
+  conrelid::regclass as table_name,
+  a.attname as fk_column
+from pg_constraint c
+join pg_attribute a on a.attrelid = c.conrelid and a.attnum = any(c.conkey)
+where c.contype = 'f'
+  and not exists (
+    select 1 from pg_index i
+    where i.indrelid = c.conrelid and a.attnum = any(i.indkey)
+  );
+```
+
+Reference: [Foreign Keys](https://www.postgresql.org/docs/current/ddl-constraints.html#DDL-CONSTRAINTS-FK)

--- a/.agents/skills/supabase-postgres-best-practices/references/schema-lowercase-identifiers.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/schema-lowercase-identifiers.md
@@ -1,0 +1,55 @@
+---
+title: Use Lowercase Identifiers for Compatibility
+impact: MEDIUM
+impactDescription: Avoid case-sensitivity bugs with tools, ORMs, and AI assistants
+tags: naming, identifiers, case-sensitivity, schema, conventions
+---
+
+## Use Lowercase Identifiers for Compatibility
+
+PostgreSQL folds unquoted identifiers to lowercase. Quoted mixed-case identifiers require quotes forever and cause issues with tools, ORMs, and AI assistants that may not recognize them.
+
+**Incorrect (mixed-case identifiers):**
+
+```sql
+-- Quoted identifiers preserve case but require quotes everywhere
+CREATE TABLE "Users" (
+  "userId" bigint PRIMARY KEY,
+  "firstName" text,
+  "lastName" text
+);
+
+-- Must always quote or queries fail
+SELECT "firstName" FROM "Users" WHERE "userId" = 1;
+
+-- This fails - Users becomes users without quotes
+SELECT firstName FROM Users;
+-- ERROR: relation "users" does not exist
+```
+
+**Correct (lowercase snake_case):**
+
+```sql
+-- Unquoted lowercase identifiers are portable and tool-friendly
+CREATE TABLE users (
+  user_id bigint PRIMARY KEY,
+  first_name text,
+  last_name text
+);
+
+-- Works without quotes, recognized by all tools
+SELECT first_name FROM users WHERE user_id = 1;
+```
+
+Common sources of mixed-case identifiers:
+
+```sql
+-- ORMs often generate quoted camelCase - configure them to use snake_case
+-- Migrations from other databases may preserve original casing
+-- Some GUI tools quote identifiers by default - disable this
+
+-- If stuck with mixed-case, create views as a compatibility layer
+CREATE VIEW users AS SELECT "userId" AS user_id, "firstName" AS first_name FROM "Users";
+```
+
+Reference: [Identifiers and Key Words](https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS)

--- a/.agents/skills/supabase-postgres-best-practices/references/schema-partitioning.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/schema-partitioning.md
@@ -1,0 +1,55 @@
+---
+title: Partition Large Tables for Better Performance
+impact: MEDIUM-HIGH
+impactDescription: 5-20x faster queries and maintenance on large tables
+tags: partitioning, large-tables, time-series, performance
+---
+
+## Partition Large Tables for Better Performance
+
+Partitioning splits a large table into smaller pieces, improving query performance and maintenance operations.
+
+**Incorrect (single large table):**
+
+```sql
+create table events (
+  id bigint generated always as identity,
+  created_at timestamptz,
+  data jsonb
+);
+
+-- 500M rows, queries scan everything
+select * from events where created_at > '2024-01-01';  -- Slow
+vacuum events;  -- Takes hours, locks table
+```
+
+**Correct (partitioned by time range):**
+
+```sql
+create table events (
+  id bigint generated always as identity,
+  created_at timestamptz not null,
+  data jsonb
+) partition by range (created_at);
+
+-- Create partitions for each month
+create table events_2024_01 partition of events
+  for values from ('2024-01-01') to ('2024-02-01');
+
+create table events_2024_02 partition of events
+  for values from ('2024-02-01') to ('2024-03-01');
+
+-- Queries only scan relevant partitions
+select * from events where created_at > '2024-01-15';  -- Only scans events_2024_01+
+
+-- Drop old data instantly
+drop table events_2023_01;  -- Instant vs DELETE taking hours
+```
+
+When to partition:
+
+- Tables > 100M rows
+- Time-series data with date-based queries
+- Need to efficiently drop old data
+
+Reference: [Table Partitioning](https://www.postgresql.org/docs/current/ddl-partitioning.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/schema-primary-keys.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/schema-primary-keys.md
@@ -1,0 +1,61 @@
+---
+title: Select Optimal Primary Key Strategy
+impact: HIGH
+impactDescription: Better index locality, reduced fragmentation
+tags: primary-key, identity, uuid, serial, schema
+---
+
+## Select Optimal Primary Key Strategy
+
+Primary key choice affects insert performance, index size, and replication
+efficiency.
+
+**Incorrect (problematic PK choices):**
+
+```sql
+-- identity is the SQL-standard approach
+create table users (
+  id serial primary key  -- Works, but IDENTITY is recommended
+);
+
+-- Random UUIDs (v4) cause index fragmentation
+create table orders (
+  id uuid default gen_random_uuid() primary key  -- UUIDv4 = random = scattered inserts
+);
+```
+
+**Correct (optimal PK strategies):**
+
+```sql
+-- Use IDENTITY for sequential IDs (SQL-standard, best for most cases)
+create table users (
+  id bigint generated always as identity primary key
+);
+
+-- For distributed systems needing UUIDs, use UUIDv7 (time-ordered)
+-- Requires pg_uuidv7 extension: create extension pg_uuidv7;
+create table orders (
+  id uuid default uuid_generate_v7() primary key  -- Time-ordered, no fragmentation
+);
+
+-- Alternative: time-prefixed IDs for sortable, distributed IDs (no extension needed)
+create table events (
+  id text default concat(
+    to_char(now() at time zone 'utc', 'YYYYMMDDHH24MISSMS'),
+    gen_random_uuid()::text
+  ) primary key
+);
+```
+
+Guidelines:
+
+- Single database: `bigint identity` (sequential, 8 bytes, SQL-standard)
+- Distributed/exposed IDs: UUIDv7 (requires pg_uuidv7) or ULID (time-ordered, no
+  fragmentation)
+- `serial` works but `identity` is SQL-standard and preferred for new
+  applications
+- Avoid random UUIDs (v4) as primary keys on large tables (causes index
+  fragmentation)
+
+Reference:
+[Identity Columns](https://www.postgresql.org/docs/current/sql-createtable.html#SQL-CREATETABLE-PARMS-GENERATED-IDENTITY)

--- a/.agents/skills/supabase-postgres-best-practices/references/security-privileges.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/security-privileges.md
@@ -1,0 +1,54 @@
+---
+title: Apply Principle of Least Privilege
+impact: MEDIUM
+impactDescription: Reduced attack surface, better audit trail
+tags: privileges, security, roles, permissions
+---
+
+## Apply Principle of Least Privilege
+
+Grant only the minimum permissions required. Never use superuser for application queries.
+
+**Incorrect (overly broad permissions):**
+
+```sql
+-- Application uses superuser connection
+-- Or grants ALL to application role
+grant all privileges on all tables in schema public to app_user;
+grant all privileges on all sequences in schema public to app_user;
+
+-- Any SQL injection becomes catastrophic
+-- drop table users; cascades to everything
+```
+
+**Correct (minimal, specific grants):**
+
+```sql
+-- Create role with no default privileges
+create role app_readonly nologin;
+
+-- Grant only SELECT on specific tables
+grant usage on schema public to app_readonly;
+grant select on public.products, public.categories to app_readonly;
+
+-- Create role for writes with limited scope
+create role app_writer nologin;
+grant usage on schema public to app_writer;
+grant select, insert, update on public.orders to app_writer;
+grant usage on sequence orders_id_seq to app_writer;
+-- No DELETE permission
+
+-- Login role inherits from these
+create role app_user login password 'xxx';
+grant app_writer to app_user;
+```
+
+Revoke public defaults:
+
+```sql
+-- Revoke default public access
+revoke all on schema public from public;
+revoke all on all tables in schema public from public;
+```
+
+Reference: [Roles and Privileges](https://supabase.com/blog/postgres-roles-and-privileges)

--- a/.agents/skills/supabase-postgres-best-practices/references/security-rls-basics.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/security-rls-basics.md
@@ -1,0 +1,50 @@
+---
+title: Enable Row Level Security for Multi-Tenant Data
+impact: CRITICAL
+impactDescription: Database-enforced tenant isolation, prevent data leaks
+tags: rls, row-level-security, multi-tenant, security
+---
+
+## Enable Row Level Security for Multi-Tenant Data
+
+Row Level Security (RLS) enforces data access at the database level, ensuring users only see their own data.
+
+**Incorrect (application-level filtering only):**
+
+```sql
+-- Relying only on application to filter
+select * from orders where user_id = $current_user_id;
+
+-- Bug or bypass means all data is exposed!
+select * from orders;  -- Returns ALL orders
+```
+
+**Correct (database-enforced RLS):**
+
+```sql
+-- Enable RLS on the table
+alter table orders enable row level security;
+
+-- Create policy for users to see only their orders
+create policy orders_user_policy on orders
+  for all
+  using (user_id = current_setting('app.current_user_id')::bigint);
+
+-- Force RLS even for table owners
+alter table orders force row level security;
+
+-- Set user context and query
+set app.current_user_id = '123';
+select * from orders;  -- Only returns orders for user 123
+```
+
+Policy for authenticated role:
+
+```sql
+create policy orders_user_policy on orders
+  for all
+  to authenticated
+  using (user_id = auth.uid());
+```
+
+Reference: [Row Level Security](https://supabase.com/docs/guides/database/postgres/row-level-security)

--- a/.agents/skills/supabase-postgres-best-practices/references/security-rls-performance.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/security-rls-performance.md
@@ -1,0 +1,57 @@
+---
+title: Optimize RLS Policies for Performance
+impact: HIGH
+impactDescription: 5-10x faster RLS queries with proper patterns
+tags: rls, performance, security, optimization
+---
+
+## Optimize RLS Policies for Performance
+
+Poorly written RLS policies can cause severe performance issues. Use subqueries and indexes strategically.
+
+**Incorrect (function called for every row):**
+
+```sql
+create policy orders_policy on orders
+  using (auth.uid() = user_id);  -- auth.uid() called per row!
+
+-- With 1M rows, auth.uid() is called 1M times
+```
+
+**Correct (wrap functions in SELECT):**
+
+```sql
+create policy orders_policy on orders
+  using ((select auth.uid()) = user_id);  -- Called once, cached
+
+-- 100x+ faster on large tables
+```
+
+Use security definer functions for complex checks:
+
+```sql
+-- Create helper function (runs as definer, bypasses RLS)
+create or replace function is_team_member(team_id bigint)
+returns boolean
+language sql
+security definer
+set search_path = ''
+as $$
+  select exists (
+    select 1 from public.team_members
+    where team_id = $1 and user_id = (select auth.uid())
+  );
+$$;
+
+-- Use in policy (indexed lookup, not per-row check)
+create policy team_orders_policy on orders
+  using ((select is_team_member(team_id)));
+```
+
+Always add indexes on columns used in RLS policies:
+
+```sql
+create index orders_user_id_idx on orders (user_id);
+```
+
+Reference: [RLS Performance](https://supabase.com/docs/guides/database/postgres/row-level-security#rls-performance-recommendations)

--- a/.agents/skills/supabase/SKILL.md
+++ b/.agents/skills/supabase/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: supabase
+description: "Use when doing ANY task involving Supabase. Triggers: Supabase products (Database, Auth, Edge Functions, Realtime, Storage, Vectors, Cron, Queues); client libraries and SSR integrations (supabase-js, @supabase/ssr) in Next.js, React, SvelteKit, Astro, Remix; auth issues (login, logout, sessions, JWT, cookies, getSession, getUser, getClaims, RLS); Supabase CLI or MCP server; schema changes, migrations, security audits, Postgres extensions (pg_graphql, pg_cron, pg_vector)."
+metadata:
+  author: supabase
+  version: "0.1.2"
+---
+
+# Supabase
+
+## Core Principles
+
+**1. Supabase changes frequently — verify against changelog and current docs before implementing.**
+Do not rely on training data for Supabase features. Function signatures, config.toml settings, and API conventions change between versions.
+
+First, fetch `https://supabase.com/changelog.md` (a lightweight summary index — not a heavy pull), scan for `breaking-change` tags relevant to your task, and follow the linked page for any that apply. Then look up the relevant topic using the documentation access methods below.
+
+**2. Verify your work.**
+After implementing any fix, run a test query to confirm the change works. A fix without verification is incomplete.
+
+**3. Recover from errors, don't loop.**
+If an approach fails after 2-3 attempts, stop and reconsider. Try a different method, check documentation, inspect the error more carefully, and review relevant logs when available. Supabase issues are not always solved by retrying the same command, and the answer is not always in the logs, but logs are often worth checking before proceeding.
+
+**4. Exposing tables to the Data API:** Depending on the user's [Data API settings](https://supabase.com/dashboard/project/<ref>/integrations/data_api/settings), newly created tables may not be automatically exposed via the Data (REST) API. If this is the case, `anon` and `authenticated` roles will need to be explicitly granted access.
+
+> Note that this is separate from RLS, which controls which _rows_ are visible once a table is accessible, not whether the table is accessible at all.
+
+When a user reports a SQL-created table is unexpectedly inaccessible, check their Data API settings and whether the roles have been granted access via explicit `GRANT` SQL. When granting public (`anon`/`authenticated`) access, always enable RLS too. See [Exposing a Table to the Data API](https://supabase.com/docs/guides/api/securing-your-api.md) for the full setup workflow.
+
+**5. RLS in exposed schemas.**
+Enable RLS on every table in any exposed schema, which includes `public` by default. This is critical in Supabase because tables in exposed schemas can be reachable through the Data API when the `anon`/`authenticated` roles have access (see [Exposing a Table to the Data API](https://supabase.com/docs/guides/api/securing-your-api.md)). For private schemas, prefer RLS as defense in depth. After enabling RLS, create policies that match the actual access model rather than defaulting every table to the same `auth.uid()` pattern.
+
+**6. Security checklist.**
+When working on any Supabase task that touches auth, RLS, views, storage, or user data, run through this checklist. These are Supabase-specific security traps that silently create vulnerabilities:
+
+- **Auth and session security**
+  - **Never use `user_metadata` claims in JWT-based authorization decisions.** In Supabase, `raw_user_meta_data` is user-editable and can appear in `auth.jwt()`, so it is unsafe for RLS policies or any other authorization logic. Store authorization data in `raw_app_meta_data` / `app_metadata` instead.
+  - **Deleting a user does not invalidate existing access tokens.** Sign out or revoke sessions first, keep JWT expiry short for sensitive apps, and for strict guarantees validate `session_id` against `auth.sessions` on sensitive operations.
+  - **If you use `app_metadata` or `auth.jwt()` for authorization, remember JWT claims are not always fresh until the user's token is refreshed.**
+
+- **API key and client exposure**
+  - **Never expose the `service_role` or secret key in public clients.** Prefer publishable keys for frontend code. Legacy `anon` keys are only for compatibility. In Next.js, any `NEXT_PUBLIC_` env var is sent to the browser.
+
+- **RLS, views, and privileged database code**
+  - **Views bypass RLS by default.** In Postgres 15 and above, use `CREATE VIEW ... WITH (security_invoker = true)`. In older versions of Postgres, protect your views by revoking access from the `anon` and `authenticated` roles, or by putting them in an unexposed schema.
+  - **UPDATE requires a SELECT policy.** In Postgres RLS, an UPDATE needs to first SELECT the row. Without a SELECT policy, updates silently return 0 rows — no error, just no change.
+  - **Do not put `security definer` functions in an exposed schema.** Keep them in a private or otherwise unexposed schema.
+
+- **Storage access control**
+  - **Storage upsert requires INSERT + SELECT + UPDATE.** Granting only INSERT allows new uploads but file replacement (upsert) silently fails. You need all three.
+
+For any security concern not covered above, fetch the Supabase product security index: `https://supabase.com/docs/guides/security/product-security.md`
+
+## Supabase CLI
+
+Always discover commands via `--help` — never guess. The CLI structure changes between versions.
+
+```bash
+supabase --help                    # All top-level commands
+supabase <group> --help            # Subcommands (e.g., supabase db --help)
+supabase <group> <command> --help  # Flags for a specific command
+```
+
+**Supabase CLI Known gotchas:**
+
+- `supabase db query` requires **CLI v2.79.0+** → use MCP `execute_sql` or `psql` as fallback
+- `supabase db advisors` requires **CLI v2.81.3+** → use MCP `get_advisors` as fallback
+- When you need a new migration SQL file, **always** create it with `supabase migration new <name>` first. Never invent a migration filename or rely on memory for the expected format.
+
+**Version check and upgrade:** Run `supabase --version` to check. For CLI changelogs and version-specific features, consult the [CLI documentation](https://supabase.com/docs/reference/cli/introduction) or [GitHub releases](https://github.com/supabase/cli/releases).
+
+## Supabase MCP Server
+
+For setup instructions, server URL, and configuration, see the [MCP setup guide](https://supabase.com/docs/guides/getting-started/mcp).
+
+**Troubleshooting connection issues** — follow these steps in order:
+
+1. **Check if the server is reachable:**
+   `curl -so /dev/null -w "%{http_code}" https://mcp.supabase.com/mcp`
+   A `401` is expected (no token) and means the server is up. Timeout or "connection refused" means it may be down.
+
+2. **Check `.mcp.json` configuration:**
+   Verify the project root has a valid `.mcp.json` with the correct server URL. If missing, create one pointing to `https://mcp.supabase.com/mcp`.
+
+3. **Authenticate the MCP server:**
+   If the server is reachable and `.mcp.json` is correct but tools aren't visible, the user needs to authenticate. The Supabase MCP server uses OAuth 2.1 — tell the user to trigger the auth flow in their agent, complete it in the browser, and reload the session.
+
+## Supabase Documentation
+
+Before implementing any Supabase feature, find the relevant documentation. Use these methods in priority order:
+
+1. **MCP `search_docs` tool** (preferred — returns relevant snippets directly)
+2. **Fetch docs pages as markdown** — any docs page can be fetched by appending `.md` to the URL path.
+3. **Web search** for Supabase-specific topics when you don't know which page to look at.
+
+## Making and Committing Schema Changes
+
+**To make schema changes, use `execute_sql` (MCP) or `supabase db query` (CLI).** These run SQL directly on the database without creating migration history entries, so you can iterate freely and generate a clean migration when ready.
+
+Do NOT use `apply_migration` to change a local database schema — it writes a migration history entry on every call, which means you can't iterate, and `supabase db diff` / `supabase db pull` will produce empty or conflicting diffs. If you use it, you'll be stuck with whatever SQL you passed on the first try.
+
+**When ready to commit** your changes to a migration file:
+
+1. **Run advisors** → `supabase db advisors` (CLI v2.81.3+) or MCP `get_advisors`. Fix any issues.
+2. **Review the Security Checklist above** if your changes involve views, functions, triggers, or storage.
+3. **Generate the migration** → `supabase db pull <descriptive-name> --local --yes`
+4. **Verify** → `supabase migration list --local`
+
+## Reference Guides
+
+- **Skill Feedback** → [references/skill-feedback.md](references/skill-feedback.md)
+  **MUST read when** the user reports that this skill gave incorrect guidance or is missing information.

--- a/.agents/skills/supabase/assets/feedback-issue-template.md
+++ b/.agents/skills/supabase/assets/feedback-issue-template.md
@@ -1,0 +1,17 @@
+## What happened
+
+**Task:** <!-- e.g., "Set up MFA on patient records" -->
+
+**Skill said:** <!-- e.g., "Use auth.jwt()->'app_metadata' in the RLS policy" -->
+
+**Expected:** <!-- e.g., "The function also needs SECURITY DEFINER + grant to supabase_auth_admin" -->
+
+## Source
+
+**File:** <!-- e.g., references/security-model.md -->
+
+**Section:** <!-- e.g., "Trust Boundaries > user_metadata vs app_metadata" -->
+
+## Fix suggestion
+
+<!-- Leave blank if unsure -->

--- a/.agents/skills/supabase/references/skill-feedback.md
+++ b/.agents/skills/supabase/references/skill-feedback.md
@@ -1,0 +1,17 @@
+# Skill Feedback
+
+Use this when the user reports that the skill gave incorrect guidance, is missing information, or could be improved. This is about the skill (agent instructions), not about Supabase the product.
+
+## Steps
+
+1. **Ask permission** — Ask the user if they'd like to submit feedback to the skill maintainers. If they decline, move on.
+
+2. **Draft the issue** — Use the template at [assets/feedback-issue-template.md](../assets/feedback-issue-template.md) to structure the feedback. Fill in the fields based on the conversation. Always identify which specific reference file and section caused the problem.
+
+3. **Submit** — Create a GitHub Issue on the `supabase/agent-skills` repository using the draft as the issue body. The title must follow this format: `user-feedback: <summary of the problem>`.
+
+4. **Share the result** — Share the issue URL with the user after submission. If submission fails, give the user this link to create the issue manually:
+
+```
+https://github.com/supabase/agent-skills/issues/new
+```

--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,14 @@ VITE_FEATURE_EDITORIAL_ENRICHMENT=false
 VITE_FEATURE_VISUAL_ENRICHMENT=false
 VITE_FEATURE_TRAKT_ENRICHMENT=false
 
+# Oracle intelligence rollout flags
+# Taste RPC enables server-side taste-profile hydration from Supabase RPC.
+VITE_FEATURE_ORACLE_TASTE_RPC=false
+# Groq intent parser enables low-latency constraint parsing before Oracle generation.
+VITE_FEATURE_ORACLE_GROQ_INTENT_PARSER=false
+# Deterministic parser constraints gate for Oracle query-intelligence behavior.
+VITE_FEATURE_ORACLE_QUERY_CONSTRAINTS=false
+
 # Playwright Test Credentials
 # Used for automated portfolio screenshots
 TEST_USER_EMAIL=your_email@example.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.12.15] - April 29, 2026
+
+### 🛠️ Changed
+
+- **Oracle intelligence integration pass (Phase 7.9)**
+  - Merged Sprint B taste-weighting upgrades and Sprint C reliability hardening into one release-ready branch.
+  - Preserved RPC-first taste hydration (`get_oracle_taste_profile`) with deterministic local fallback (`buildUserTasteProfile` / `buildTasteContextString`).
+  - Preserved Groq intent parsing fast-path with deterministic query parser fallback for Oracle constraints.
+  - Added provider-specific reliability controls in Oracle orchestration (timeouts, bounded retries, abort-safe reroll/discover flow, and deterministic fallback sequencing).
+  - Added normalized failure telemetry buckets/stage tagging for `oracle_provider_events` compatibility and observability.
+  - Kept UI-safe recommendation payload normalization for fallback paths (`rationale` / `vibeCheck` always present).
+
+### ✅ Quality
+
+- Combined Oracle regression suite passes: `npx playwright test "tests/oracle-query-intelligence.spec.ts"` (55 passed).
+- Production build succeeds: `npm run build`.
+- Release metadata synced to `v1.12.15` across `package.json`, `src/constants.js`, and roadmap current-version status.
+
+---
+
 ## [1.12.12] - April 28, 2026
 
 ### 🚀 Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Refactored Oracle recommendation rendering into `OracleContext` + `ResultCard` and fixed reroll regression so single-card rerolls replace only the targeted recommendation instead of globally refreshing the entire set.
   - Added Oracle streaming context badges by mapping TMDB provider logos and rendering matched `user_providers` directly on each result card.
   - Added list-membership race guard migration (`list_members` dedupe + unique index on `list_id,user_id`) and hardened shared-list API writes with `upsert(..., { onConflict: 'list_id,user_id' })`.
+- **Oracle intelligence pass (Phase 7.9)**
+  - Added post-generation recommendation guardrails in `src/utils/gemini.js` to normalize output, remove duplicates, and enforce rejected-title exclusion before cards render.
+  - Added quality-floor enforcement so thin model output is topped up with deterministic TMDB fallback picks to preserve stable recommendation sets.
+  - Applied the same quality guardrail pass across both Gemini and OpenRouter Oracle response paths for more consistent discovery behavior.
+  - Upgraded Oracle taste-context hydration in `src/context/OracleContext.jsx` to derive user vibe signals from moods, genres, rating polarity, decade preference, and recent behavior before prompt assembly.
+  - Expanded taste weighting with deterministic mood/genre affinity scoring (frequency + bounded recency + high-rating lift), rating polarity buckets, and strict per-section caps to keep prompt context stable for large libraries.
+  - Added explicit avoid-like guidance from low-rated watched logs (`<= 2.5`) and ensured it remains in the Oracle context even when slices are truncated.
+  - Added Oracle weighting regression tests validating weighted context sections and avoid-like truncation behavior in `tests/oracle-query-intelligence.spec.ts`.
+  - Added Supabase RPC `get_oracle_taste_profile(p_user_id)` for server-side Oracle context hydration, then wired Oracle to use RPC-first with fail-soft fallback to local taste aggregation when RPC is unavailable.
+  - Added feature-flagged low-latency Groq intent parsing for Oracle query constraints (`VITE_FEATURE_ORACLE_GROQ_INTENT_PARSER=true`) with deterministic parser fallback to preserve reliability.
+  - Added Oracle constraint resolver tests covering Groq success/fallback behavior and RPC-compatible context ordering assertions.
+  - Documented rollout toggles in `.env.example` for Oracle RPC hydration (`VITE_FEATURE_ORACLE_TASTE_RPC`) and Groq constraint parsing (`VITE_FEATURE_ORACLE_GROQ_INTENT_PARSER`).
+  - Added a ranked `Now / Next / Later` execution order in `ROADMAP.md` for deferred Oracle upgrades (filter intelligence, reliability, media expansion, and polish tracks).
+  - Implemented Sprint A query intelligence: Oracle now parses compound prompt constraints (year bounds, genre hints, watch-status intent), passes deterministic `queryConstraints` through orchestration, and applies year/genre-aligned fallback filtering.
+  - Added safety toggle `VITE_FEATURE_ORACLE_QUERY_CONSTRAINTS` so constraint behavior can be enabled without removing legacy Oracle flow.
+  - Added parser validation coverage in `tests/oracle-query-intelligence.spec.ts` including prompts like “pre-1960 horror on my watchlist”.
+  - Implemented Sprint C reliability hardening: provider-specific timeout/retry contracts (`Gemini/OpenRouter=9000ms`, `TMDB=6000ms`) with deterministic fallback progression across Gemini -> OpenRouter -> TMDB.
+  - Added abort-aware Oracle request orchestration in `OracleContext` so rerolls/new discovery/unmount cancel in-flight work and ignore stale late responses.
+  - Added UI-safe fallback payload normalization to guarantee non-empty `rationale` and `vibeCheck` fields when metadata fallback paths are used.
+  - Expanded Oracle failure observability with normalized `failure_bucket` (`rate_limit`, `parse_fail`, `timeout`, `upstream_unavailable`, `unknown`) and additive `failure_stage` tags for Supabase analytics compatibility.
+  - Added reliability regression coverage for bucket mapping, retry policy boundaries, fallback shape safety, and abort classification in `tests/oracle-query-intelligence.spec.ts`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -602,25 +602,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## Latest Version: 1.8.0 (March 29, 2026)
-
-**Highlights:**
-
-- 🔮 **Oracle** - AI-powered movie discovery with mood-based recommendations
-- 🤝 **The Matchmaker** - Social compatibility feature for comparing movie tastes with friends
-- 🎭 **6 Mood Presets** - Quick-select bubbles for instant vibe matching
-- 📱 **Mobile Navigation** - Discover page movie cards now clickable
-- 🎨 **Deep Ember Theme** - Consistent dark aesthetic with amber/orange accents
-
-**Quick Links:**
-
-- [Full v1.8.0 Notes](#180---march-29-2026)
-- [Previous: v1.7.0](#170---march-28-2026)
-- [Roadmap](./ROADMAP.md)
-- [README](./README.md)
-
----
-
 ## [1.8.0] - March 29, 2026
 
 ### 🚀 Added
@@ -1119,97 +1100,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Better Component Structure** - Separated skeleton loading components
 - **Reduced Code Bloat** - Net reduction of 110 lines while adding features
 
-### 🛠️ Changed
-
-#### Frontend (`src/pages/LibraryPage.jsx`)
-
-- **Magic Import Button** - Added "✨ Magic Import" button in library header
-- **Import Modal Integration** - `showImportModal` state and `ArchiveImporterModal` component
-- **Refresh Handler** - Library refreshes automatically after successful import
-
-#### New Files
-
-- **ArchiveImporterModal.jsx** - 4-step modal component with React Portal
-- **ArchiveImporterModal.css** - Deep Ember themed modal styling
-- **importer.js** - Utility module with Groq parsing and TMDB verification
-
-#### Backend (`src/utils/importer.js`)
-
-- **`parseArchiveWithGroq()`** - Groq API integration with system prompt engineering
-- **`verifyBatchWithTMDB()`** - Batch TMDB verification with error handling
-- **`batchSaveMovies()`** - Optimized single-request UPSERT for movie_logs table
-
-### ⚡ Performance
-
-#### Parallel Processing
-
-- **Groq Parsing** - ~300-600ms for typical lists (10-30 movies)
-- **TMDB Verification** - Parallel fetching reduces total time by 70-80%
-- **Batch Save** - Single network request vs. N individual inserts
-
-#### Deduplication Efficiency
-
-- **Database-Level** - `onConflict` constraint handles duplicates automatically
-- **No Pre-Checks Needed** - Eliminates need for separate existence queries
-- **Skipped Count Tracking** - Reports how many movies were already in library
-
-### 🎨 UI/UX
-
-#### Modal Design
-
-- **Step-by-Step Wizard** - Clear progression with visual feedback
-- **Review Grid** - Card-based layout with posters and parsed vs. TMDB titles
-- **Checkbox Selection** - Individual toggle with select/deselect all actions
-- **Loading States** - Spinner and progress indicators during verification
-- **Success Stats** - Post-import breakdown of saved/skipped/errors
-
-#### Deep Ember Theme
-
-- **Dark Zinc Backgrounds** - Consistent with app aesthetic
-- **Amber Accents** - Orange highlights for primary actions
-- **Status Indicators** - Red for not found, green for success
-- **Responsive Grid** - Multi-column layout for review cards
-
-### 📝 Documentation
-
-#### Updated Files
-
-- **CHANGELOG.md** - Comprehensive v1.5.0 release notes
-- **README.md** - Magic Importer feature documentation
-- **ROADMAP.md** - Bulk import marked as complete
-
-### 🐛 Fixed
-
-#### Bug Fixes
-
-- **Modal Portal Rendering** - Uses `createPortal` for proper z-index stacking
-- **Checkbox Event Bubbling** - `stopPropagation` prevents card click conflicts
-- **Empty State Handling** - Graceful handling of lists with no custom lists
-- **Year Parsing** - Handles "N/A" for movies without release years
-- **Poster Fallback** - Shows "No Poster" placeholder when TMDB has no image
-- **Groq JSON Parsing** - Handles single movie objects in addition to arrays
-- **Single Movie Import** - Now accepts titles without years (e.g., "Shrek", "Jaws")
-
----
-
-## [1.4.1] - March 26, 2026
-
-**Highlights:**
-
-- 🧠 **Personalized Oracle** - AI now knows your ENTIRE movie history (zero duplicates guaranteed)
-- 📚 **Three-Bucket Memory Fetch** - Watched + Watchlist + Custom Lists loaded in parallel
-- 🎯 **Taste Triangulation** - AI analyzes your high-rated films before recommending
-- ⚡ **Optimized Supabase Joins** - Efficient `lists!inner(user_id)` join for custom lists
-
-**Quick Links:**
-
-- [Full v1.4.1 Notes](#141---march-26-2026)
-- [Previous: v1.4.0](#140---march-26-2026)
-- [Roadmap](./ROADMAP.md)
-- [README](./README.md)
-
----
-
 ## [1.4.1] - March 26, 2026
 
 ### 🚀 Added
@@ -1431,26 +1321,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## Latest Version: 1.3.8 (March 24, 2026)
-
-**Highlights:**
-
-- 🔧 Logo text "FILMGRAPH" now visible on all screen sizes
-- 📝 Changelog page with dedicated route (/changelog)
-- 🤖 Oracle with Reject & Reroll feature
-- 🔐 Remember Me checkbox with dynamic storage
-- 📱 Responsive library grid (`grid-cols-2 md:grid-cols-4 lg:grid-cols-6`)
-- 🎯 Oracle vibe mapping fixed - "Brain Mush" now works
-
-**Quick Links:**
-
-- [Full v1.3.8 Notes](#138---march-24-2026)
-- [Oracle v1.3.2](#132---march-24-2026)
-- [Roadmap](./ROADMAP.md)
-- [README](./README.md)
-
----
-
 ## [1.3.8] - March 24, 2026
 
 ### 🐛 Fixed
@@ -1531,7 +1401,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.3.5] - 2026-03-24
+## [1.3.5] - March 24, 2026
 
 ### 🐛 Fixed
 
@@ -1571,7 +1441,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.3.4] - 2026-03-24
+## [1.3.4] - March 24, 2026
 
 ### 🧠 Fixed
 
@@ -1599,7 +1469,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.3.3] - 2026-03-24
+## [1.3.3] - March 24, 2026
 
 ### 🔐 Added
 
@@ -1634,7 +1504,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.3.2] - 2026-03-24
+## [1.3.2] - March 24, 2026
 
 ### 🎉 Added
 
@@ -1673,7 +1543,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.3.1] - 2026-03-24
+## [1.3.1] - March 24, 2026
 
 ### 🐛 Fixed
 
@@ -1701,7 +1571,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.3.0] - 2026-03-24
+## [1.3.0] - March 24, 2026
 
 ### 🎉 Added
 
@@ -1774,7 +1644,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.2.0] - 2026-03-24
+## [1.2.0] - March 24, 2026
 
 ### 🎉 Added
 
@@ -1848,7 +1718,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.1.0] - 2026-03-24
+## [1.1.0] - March 24, 2026
 
 ### 🎉 Added
 
@@ -1904,7 +1774,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.0.0] - 2026-03-XX
+## [1.0.0] - March XX, 2026
 
 ### 🎉 Initial Release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Development
+
+- Added official [Supabase Agent Skills](https://github.com/supabase/agent-skills) under `.agents/skills/` (`supabase`, `supabase-postgres-best-practices`) for Cursor and other agents. Refresh with `npx skills add supabase/agent-skills`.
+
 ### 🧪 Next
 
 - **UX overhaul sprint (Phase 7.6)**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added abort-aware Oracle request orchestration in `OracleContext` so rerolls/new discovery/unmount cancel in-flight work and ignore stale late responses.
   - Added UI-safe fallback payload normalization to guarantee non-empty `rationale` and `vibeCheck` fields when metadata fallback paths are used.
   - Expanded Oracle failure observability with normalized `failure_bucket` (`rate_limit`, `parse_fail`, `timeout`, `upstream_unavailable`, `unknown`) and additive `failure_stage` tags for Supabase analytics compatibility.
+  - Added additive `oracle_provider_events` migration coverage for `failure_bucket` and `failure_stage` so runtime telemetry fields remain schema-safe.
   - Added reliability regression coverage for bucket mapping, retry policy boundaries, fallback shape safety, and abort classification in `tests/oracle-query-intelligence.spec.ts`.
+  - Expanded `oracle_provider_events` telemetry with additive hybrid metrics fields: `input_recommendation_count`, `post_filter_recommendation_count`, `dedupe_dropped_count`, `rejected_violation_attempt_count`, `provider_attempt_count`, `fallback_depth`, and `provider_attempts` JSON.
+  - Wired Oracle analytics payload mapping to persist expanded `_meta.qualityMetrics` and `_meta.attemptMetrics` safely while preserving legacy payload compatibility when telemetry blocks are absent.
+  - Added reroll-one analytics persistence and failure-path telemetry carry-through so discover/reroll flows both emit provider-attempt detail.
+  - Persisted provider-selection and ranking impact telemetry in `oracle_provider_events` (`selected_provider_ids`, `provider_match_count`, `provider_filtered_out_count`) while keeping payload defaults backward-compatible.
+  - Added deterministic provider-aware recommendation ranking after TMDB/provider enrichment so provider-matched cards are promoted first without hiding non-matches.
+  - Kept reroll-one index replacement behavior intact while applying ranking to full discover/reroll-all flows only.
+  - Extended Oracle query-intelligence tests with telemetry payload coverage for metric mapping, provider-attempt normalization, fallback-depth behavior, and backward compatibility.
+  - Added ranking regression coverage for deterministic provider promotion and no-preferences pass-through ordering.
+
+---
+
+## [1.12.21] - May 6, 2026
+
+### Fixed
+
+- **Trending cards:** The two quick actions looked like duplicate “+” buttons; **Add to list** now uses a **list** icon and **Log** uses a **pencil** icon, with clearer `aria-label`s on icon-only controls.
+- **Add-to-list menu clipped:** Parent cards used `overflow: hidden`, which cut off the list dropdown (truncated text like “…movies”). Trending **backdrop images** are clipped inside `.backdrop-media-clip` only; search **movie posters** use `.movie-card-poster-clip` the same way so the card no longer clips the menu. Narrow screens use a safer dropdown width (`min(280px, 100vw - padding)`).
+
+---
+
+## [1.12.20] - May 6, 2026
+
+### Changed
+
+- Removed the **Creepster** display font (Google Fonts + `.font-creepster` utility). Page titles and the “Signal Lost” empty state now use the app’s system sans stack; **Matchmaker** and **Profile** social headings match the rest of the UI.
+
+---
+
+## [1.12.19] - May 6, 2026
+
+### Fixed
+
+- **Year in Review / Supabase:** Stopped selecting `movie_logs.watched_at` until the column exists. Recap dates use `created_at` from the query; `buildYearInReview` still supports `watched_at` on the log object when present (e.g. after migration). Added migration `20260507120000_movie_logs_watched_at.sql` to add optional `watched_at` for future use.
+
+---
+
+## [1.12.18] - May 6, 2026
+
+### Added
+
+- **Year in Review (Phase 6.8)** — Profile links to **`/year-in-review`**, a wrapped-style recap by calendar year: films watched (status watched + hybrid log dates), monthly counts, rating distribution and average (rated logs only), top genres and moods, physical UPC count, and reviews written. Year picker covers 2015–current year; optional URL **`/year-in-review/:year`**. Aggregation is client-side via **`buildYearInReview`** in `src/utils/yearInReview.js`. See **`artifacts/adr-year-in-review.md`** for date and metric rules.
+
+---
+
+## [1.12.17] - May 6, 2026
+
+### Fixed
+
+- **Oracle Discovery**: Single-card **Reroll** now invokes `handleRerollByTmdbId` from context (previously referenced an undefined `onRerollByTmdbId`, which threw at runtime when rerolling one recommendation).
+
+### Changed
+
+- **ESLint**: Ignore Capacitor `android/**` and `public/sw.js` so `npm run lint` does not parse generated native bundles or the service worker as generic scripts. Added global `settings.react.version` (`detect`) to silence redundant React plugin warnings.
+- Tidied unused destructuring names in shared-list list-item fallbacks (`sharedLists.js`, `ArchiveImporterModal.jsx`) so lint stays warning-clean for those paths.
+
+---
+
+## [1.12.16] - May 6, 2026
+
+### Added
+
+- **Library Advanced Search (Phase 6.10)** — On **Library** → **Find & refine**, open **Advanced search** to combine mood chips (palette-aligned, any/all moods), genre checkboxes from your logged TMDB genres, and min/max **your rating** (0–5, 0.5 steps). Filters apply to the current shelf (Watched, Watchlist, or Collection) and respect title search, smart filter, and sort. Global TMDB **Search** is unchanged.
 
 ---
 
@@ -66,7 +129,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ✅ Quality
 
-- Combined Oracle regression suite passes: `npx playwright test "tests/oracle-query-intelligence.spec.ts"` (55 passed).
+- Combined Oracle regression suite passes: `npx playwright test "tests/oracle-query-intelligence.spec.ts"`.
 - Production build succeeds: `npm run build`.
 - Release metadata synced to `v1.12.15` across `package.json`, `src/constants.js`, and roadmap current-version status.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.12.23] - May 13, 2026
+
+### Changed
+
+- **Oracle / Gemini:** Reordered the Gemini model ladder to try **`gemini-2.0-flash` before `gemini-3.1-flash-lite`** for lower typical latency; **`gemini-3.1-flash-lite`** remains next in the chain so API keys that lack 2.0 or hit 2.0-only errors still get a modern GA fallback, followed by the existing 2.x / 1.5 model IDs before downstream OpenRouter and TMDB fallbacks.
+
+---
+
+## [1.12.22] - May 12, 2026
+
+### Changed
+
+- **Oracle:** Gemini ladder now tries **`gemini-3.1-flash-lite` (GA)** first, with existing Gemini 2.x / 1.5 model IDs as fallbacks when a candidate is unavailable or errors (Google preview retirement).
+
+---
+
 ## [1.12.21] - May 6, 2026
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -201,6 +201,14 @@ If `VERCEL_TOKEN` is missing, the workflow exits gracefully and publishes a setu
 
 See [ROADMAP.md](./ROADMAP.md) for the detailed development plan.
 
+### Supabase Agent Skills (Cursor)
+
+Official [Supabase Agent Skills](https://github.com/supabase/agent-skills) are vendored under `.agents/skills/` for better RLS and client-library guidance in AI-assisted edits. To install or refresh:
+
+```bash
+npx skills add supabase/agent-skills
+```
+
 ### Current Status: Phase 6 In Progress 🚀
 
 **Phase 5: AI Integration** is complete with:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,8 +6,8 @@ A phased approach to building Filmgraph from a static UI to a fully-featured mov
 
 ## 🔥 Immediate Priority: Oracle Intelligence Pass (Phase 7.9)
 
-**Status**: 🚧 **In Progress**  
-**Priority**: 🔥 **Critical (Next Priority)**
+**Status**: 🟡 **Partially Complete (Sprints A-C shipped; follow-ons deferred)**  
+**Priority**: 🔥 **Critical (Deferred Follow-Ons)**
 
 Use this as the primary execution track when Oracle work resumes.
 
@@ -1043,12 +1043,12 @@ User Query → Groq LPU (llama-3.3-70b-versatile) → Genre IDs (300-600ms)
 
 ## Phase 7.9: Oracle Intelligence Pass 🧠
 
-**Status**: 🚧 **In Progress**
-**Priority**: 🔥 **Critical (Next Priority)**
+**Status**: 🟡 **Partially Complete (Sprints A-C shipped; follow-ons deferred)**
+**Priority**: 🔥 **Critical (Deferred Follow-Ons)**
 
 **Goal**: Make Oracle recommendations smarter, stricter, and more resilient by enforcing post-generation quality checks and improving recommendation relevance.
 
-> **Execution Note**: Keep this track prioritized in planning, but defer remaining implementation work to a later sprint.
+> **Execution Note**: Sprint A/B/C integration is complete in the current release pass; keep this track prioritized for follow-up work in telemetry expansion (`7.9.4`) and provider-aware relevance ranking (`7.9.5`).
 
 ### Ranked Implementation Order (Now / Next / Later)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ A phased approach to building Filmgraph from a static UI to a fully-featured mov
 
 ## 🔥 Immediate Priority: Oracle Intelligence Pass (Phase 7.9)
 
-**Status**: 🛠️ **Planned (Queued)**  
+**Status**: 🚧 **In Progress**  
 **Priority**: 🔥 **Critical (Next Priority)**
 
 Use this as the primary execution track when Oracle work resumes.
@@ -502,7 +502,7 @@ $ git log --all --full-history -- .env
 
 **Phase**: Phase 7.1 + 7.2 + 7.3 core foundations + Streaming Oracle MVP + UI foundation shipped ✅
 
-**Current Version**: v1.12.14 - Pre-launch bug squash (Oracle reroll + shared-list uniqueness + streaming logos)
+**Current Version**: v1.12.15 - Oracle intelligence integration pass (Sprint B taste weighting + Sprint C reliability hardening)
 
 **Completed Features**:
 
@@ -1043,7 +1043,7 @@ User Query → Groq LPU (llama-3.3-70b-versatile) → Genre IDs (300-600ms)
 
 ## Phase 7.9: Oracle Intelligence Pass 🧠
 
-**Status**: 🛠️ **Planned (Queued)**
+**Status**: 🚧 **In Progress**
 **Priority**: 🔥 **Critical (Next Priority)**
 
 **Goal**: Make Oracle recommendations smarter, stricter, and more resilient by enforcing post-generation quality checks and improving recommendation relevance.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,6 +4,23 @@ A phased approach to building Filmgraph from a static UI to a fully-featured mov
 
 ---
 
+## 🔥 Immediate Priority: Oracle Intelligence Pass (Phase 7.9)
+
+**Status**: 🛠️ **Planned (Queued)**  
+**Priority**: 🔥 **Critical (Next Priority)**
+
+Use this as the primary execution track when Oracle work resumes.
+
+### Quick Jump
+
+- Full section: **Phase 7.9: Oracle Intelligence Pass 🧠**
+- Deferred implementation plan: **Deferred Sprint Checklist (Now Track)**
+  - **Sprint A**: Query Intelligence
+  - **Sprint B**: Taste Weighting
+  - **Sprint C**: Reliability Hardening
+
+---
+
 ## Phase 1: The "Visuals" (Frontend Layout) 🎨
 
 **Goal**: Create a polished, app-like interface using static/hardcoded data.
@@ -1021,6 +1038,97 @@ User Query → Groq LPU (llama-3.3-70b-versatile) → Genre IDs (300-600ms)
 - [x] Rerolling a single recommendation updates only that card.
 - [x] Collaborator list views no longer show duplicate list entries from duplicate membership rows.
 - [x] Oracle cards display only streaming logos that match `user_providers`.
+
+---
+
+## Phase 7.9: Oracle Intelligence Pass 🧠
+
+**Status**: 🛠️ **Planned (Queued)**
+**Priority**: 🔥 **Critical (Next Priority)**
+
+**Goal**: Make Oracle recommendations smarter, stricter, and more resilient by enforcing post-generation quality checks and improving recommendation relevance.
+
+> **Execution Note**: Keep this track prioritized in planning, but defer remaining implementation work to a later sprint.
+
+### Ranked Implementation Order (Now / Next / Later)
+
+#### Now (highest ROI)
+
+- **Natural-language Oracle filters**
+  - Goal: Support compound queries like "pre-1960 horror on my watchlist" with year/genre/library-state constraints.
+  - Done when: Oracle reliably parses and applies at least year + genre + watch-status filters in one request.
+- **Prompt + taste-profile weighting refinement**
+  - Goal: Improve relevance using stronger weighting for moods, genre affinity, rating polarity, and recency.
+  - Done when: Prompt context consistently includes weighted taste signals and avoids low-rated lookalikes.
+- **Reliability hardening**
+  - Goal: Reduce failed responses/timeouts under provider instability.
+  - Done when: Oracle maintains stable fallback behavior and provider failures no longer produce user-facing dead-ends.
+
+#### Next (high value, broader scope)
+
+- **Provider freshness + relevance ranking**
+  - Goal: Rank recommendations by likelihood of immediate availability on selected services.
+  - Done when: Result ordering prioritizes watch-now options and tracks conversion impact.
+- **TV expansion groundwork**
+  - Goal: Extend Oracle to series-level TV discovery while keeping movie flow stable.
+  - Done when: Movie/TV media-type routing and recommendation verification support both surfaces.
+- **List overlap intelligence ("Matchmaker for Lists")**
+  - Goal: Find intersections across personal and curated lists to drive higher-intent discovery.
+  - Done when: Users can query overlap sets (for example, Criterion vs Watchlist) from discovery workflows.
+
+#### Later (differentiation / polish)
+
+- **Oracle hero interaction polish**
+  - Goal: Make discovery feel premium with progressive reveal animation and richer visual treatment.
+  - Done when: Motion and hierarchy improvements ship without adding interaction friction.
+- **Group discovery ("Porch Talk" protocol)**
+  - Goal: Convert solo discovery into consensus-ready group viewing workflows.
+  - Done when: Bracket-based group voting and winner surfacing are available for shared sessions.
+
+### Deferred Sprint Checklist (Now Track)
+
+#### Sprint A — Query Intelligence
+
+- [x] Implement compound natural-language parsing for Oracle (year range + genre + library-state in a single query).
+- [x] Add deterministic constraint mapping for `watch_status` and decade/year filters before model call.
+- [x] Add validation tests for representative prompts (for example: "pre-1960 horror on my watchlist").
+- [x] Ship behind a safe toggle so fallback Oracle behavior remains available (`VITE_FEATURE_ORACLE_QUERY_CONSTRAINTS=true`).
+
+#### Sprint B — Taste Weighting
+
+- [x] Expand taste-profile weighting rules for mood affinity, genre repetition, rating polarity, and recency.
+- [x] Encode "avoid-like" signals from low-rated watched logs directly into prompt context.
+- [x] Cap and prioritize context slices to prevent token bloat while preserving relevance.
+- [x] Verify recommendation quality on seeded user personas (cozy, noir, deep-cuts, mind-bending).
+- [x] Add server-side taste-profile RPC (`get_oracle_taste_profile`) with fail-soft local fallback (`VITE_FEATURE_ORACLE_TASTE_RPC=true`).
+- [x] Add fast Groq intent-parser lane for Oracle constraints with deterministic-parser fallback (`VITE_FEATURE_ORACLE_GROQ_INTENT_PARSER=true`).
+
+#### Sprint C — Reliability Hardening
+
+- [x] Add stricter timeout/retry behavior per provider with clear fallback reason tagging.
+- [x] Ensure Oracle never returns an empty user-facing state when at least one provider path is healthy.
+- [x] Add observability for failure mode buckets (rate-limit, parse-fail, timeout, upstream unavailable).
+- [x] Run regression pass for discover, reroll-one, and reroll-all flows under simulated provider failures.
+
+### Tasks
+
+| # | Task | Description | Status |
+| --- | --- | --- | --- |
+| 7.9.1 | **Post-Generation Guardrails** | Normalize and validate recommendation payloads (dedupe, rejected-title exclusion, schema safety). | ✅ |
+| 7.9.2 | **Quality Floor Enforcement** | Enforce 3-5 high-quality recommendations and top-up with deterministic fallback when model output is thin. | ✅ |
+| 7.9.3 | **Cross-Provider Consistency** | Apply the same guardrails to Gemini and OpenRouter responses before UI render. | ✅ |
+| 7.9.4 | **Oracle Telemetry Expansion** | Add smarter quality metrics (dedupe drops, rejection-violation attempts, post-filter counts). | ⏳ |
+| 7.9.5 | **Provider-Aware Relevance Ranking** | Prioritize suggestions likely available on selected streaming providers before final card ordering. | ⏳ |
+| 7.9.6 | **Taste-Profile Context Hydration** | Build richer user taste context from moods, genres, ratings, decades, recency, and avoid-signals before Oracle generation. | ✅ |
+
+### Success Criteria
+
+- [x] Duplicate titles are removed before Oracle cards render.
+- [x] Rejected titles are excluded with case-insensitive matching.
+- [x] Oracle returns a stable 3-5 recommendation set whenever providers are available.
+- [x] Oracle prompt context reflects user vibe patterns (moods/genres/ratings/decades/recency), not just raw title history.
+- [ ] Analytics captures recommendation quality signals for ongoing tuning.
+- [ ] Provider-aware ranking improves watch-now conversion in discovery flow.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,15 +6,15 @@ A phased approach to building Filmgraph from a static UI to a fully-featured mov
 
 ## 🔥 Immediate Priority: Oracle Intelligence Pass (Phase 7.9)
 
-**Status**: 🟡 **Partially Complete (Sprints A-C shipped; follow-ons deferred)**  
-**Priority**: 🔥 **Critical (Deferred Follow-Ons)**
+**Status**: ✅ **Complete (Sprints A-C + follow-ons shipped)**  
+**Priority**: ✅ **Shipped**
 
 Use this as the primary execution track when Oracle work resumes.
 
 ### Quick Jump
 
 - Full section: **Phase 7.9: Oracle Intelligence Pass 🧠**
-- Deferred implementation plan: **Deferred Sprint Checklist (Now Track)**
+- Implementation checklist: **Deferred Sprint Checklist (Now Track)**
   - **Sprint A**: Query Intelligence
   - **Sprint B**: Taste Weighting
   - **Sprint C**: Reliability Hardening
@@ -276,14 +276,18 @@ GET /?apikey={key}&i={imdb_id}&plot=full
 | 6.5  | **Mobile App (Deferred)**    | React Native version for iOS/Android (pushed back)           | ⏸️     |
 | 6.6  | **Light Mode**               | Theme toggle (currently dark mode only)                      | ⬜     |
 | 6.7  | **Social Features**          | Friends, following, and activity feeds                       | ✅     |
-| 6.8  | **Year in Review**           | Annual wrapped-style statistics summary                      | ⬜     |
+| 6.8  | **Year in Review**           | Annual wrapped-style statistics summary                      | ✅     |
 | 6.9  | **Custom Lists**             | User-created movie collections                               | ✅     |
-| 6.10 | **Advanced Search**          | Multi-criteria search (Mood, Genre, Rating)                  | ⬜     |
+| 6.10 | **Advanced Search**          | Multi-criteria search (Mood, Genre, Rating)                  | ✅     |
 | 6.11 | **The Archive Importer**     | Mass import tool for migrating movie lists                   | ✅     |
 | 6.12 | **Bug Report System**        | In-app bug reporting with admin dashboard                    | ✅     |
 | 6.13 | **The Oracle**               | Conversational AI Librarian using personal logs              | ✅     |
 | 6.14 | **The Matchmaker**           | Compare watch-lists & mood overlaps with friends             | ✅     |
 | 6.15 | **High-Speed AI Ensemble**   | Groq LPU integration for sub-500ms vibe-to-genre translation | ✅     |
+
+### Phase 6.8: Year in Review — ADR
+
+Implementation decisions (canonical dates, timezone, Tier 1 metrics, client aggregation) are recorded in **[artifacts/adr-year-in-review.md](artifacts/adr-year-in-review.md)**.
 
 ### Deliverables
 
@@ -1043,12 +1047,12 @@ User Query → Groq LPU (llama-3.3-70b-versatile) → Genre IDs (300-600ms)
 
 ## Phase 7.9: Oracle Intelligence Pass 🧠
 
-**Status**: 🟡 **Partially Complete (Sprints A-C shipped; follow-ons deferred)**
-**Priority**: 🔥 **Critical (Deferred Follow-Ons)**
+**Status**: ✅ **Complete (Sprints A-C + follow-ons shipped)**
+**Priority**: ✅ **Shipped**
 
 **Goal**: Make Oracle recommendations smarter, stricter, and more resilient by enforcing post-generation quality checks and improving recommendation relevance.
 
-> **Execution Note**: Sprint A/B/C integration is complete in the current release pass; keep this track prioritized for follow-up work in telemetry expansion (`7.9.4`) and provider-aware relevance ranking (`7.9.5`).
+> **Execution Note**: Sprint A/B/C integration shipped first, followed by `7.9.4` telemetry expansion and `7.9.5` provider-aware ranking in the same stabilization pass.
 
 ### Ranked Implementation Order (Now / Next / Later)
 
@@ -1117,8 +1121,8 @@ User Query → Groq LPU (llama-3.3-70b-versatile) → Genre IDs (300-600ms)
 | 7.9.1 | **Post-Generation Guardrails** | Normalize and validate recommendation payloads (dedupe, rejected-title exclusion, schema safety). | ✅ |
 | 7.9.2 | **Quality Floor Enforcement** | Enforce 3-5 high-quality recommendations and top-up with deterministic fallback when model output is thin. | ✅ |
 | 7.9.3 | **Cross-Provider Consistency** | Apply the same guardrails to Gemini and OpenRouter responses before UI render. | ✅ |
-| 7.9.4 | **Oracle Telemetry Expansion** | Add smarter quality metrics (dedupe drops, rejection-violation attempts, post-filter counts). | ⏳ |
-| 7.9.5 | **Provider-Aware Relevance Ranking** | Prioritize suggestions likely available on selected streaming providers before final card ordering. | ⏳ |
+| 7.9.4 | **Oracle Telemetry Expansion** | Add smarter quality metrics (dedupe drops, rejection-violation attempts, post-filter counts) plus provider-attempt traces (`provider_attempts` JSON) with additive `oracle_provider_events` compatibility. | ✅ |
+| 7.9.5 | **Provider-Aware Relevance Ranking** | Prioritize suggestions likely available on selected streaming providers before final card ordering. | ✅ |
 | 7.9.6 | **Taste-Profile Context Hydration** | Build richer user taste context from moods, genres, ratings, decades, recency, and avoid-signals before Oracle generation. | ✅ |
 
 ### Success Criteria
@@ -1127,8 +1131,8 @@ User Query → Groq LPU (llama-3.3-70b-versatile) → Genre IDs (300-600ms)
 - [x] Rejected titles are excluded with case-insensitive matching.
 - [x] Oracle returns a stable 3-5 recommendation set whenever providers are available.
 - [x] Oracle prompt context reflects user vibe patterns (moods/genres/ratings/decades/recency), not just raw title history.
-- [ ] Analytics captures recommendation quality signals for ongoing tuning.
-- [ ] Provider-aware ranking improves watch-now conversion in discovery flow.
+- [x] Analytics captures recommendation quality signals for ongoing tuning.
+- [x] Provider-aware ranking prioritizes provider-matched results while preserving reorder-only behavior and reroll index safety.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -653,7 +653,7 @@ $ git log --all --full-history -- .env
 1. **User Submits Vibe Query** - "I want something dark and mind-bending"
 2. **Groq LPU Processing** - `llama-3.3-70b-versatile` instantly parses natural language → genre IDs (300-600ms)
 3. **Latency Achieved** - Sub-500ms average response for vibe-to-genre translation ✅
-4. **Gemini Deep Reasoning** - Complex recommendations use Gemini 3.1 Flash Lite Preview
+4. **Gemini Deep Reasoning** - Oracle walks a **Gemini model ladder** (see `src/utils/gemini.js`): **`gemini-2.0-flash` before `gemini-3.1-flash-lite`** for lower typical latency, then additional 2.x / 1.5 IDs when a candidate is unavailable or errors.
 5. **Multi-Movie Response** - 3-5 curated films with fast genre mapping + rich cinematic analysis
 
 ### Architecture (Live)
@@ -661,7 +661,7 @@ $ git log --all --full-history -- .env
 ```
 User Query → Groq LPU (llama-3.3-70b-versatile) → Genre IDs (300-600ms)
            ↓
-    Gemini 3.1 Flash Lite → 3-5 Movies + Deep Analysis + Rationale
+    Gemini ladder (2.0 Flash → 3.1 Flash Lite (GA) → …) → 3-5 Movies + Deep Analysis + Rationale
            ↓
     Oracle UI → Posters + Years + "Why Filmgraph Picked This" (per movie)
 ```
@@ -703,11 +703,10 @@ User Query → Groq LPU (llama-3.3-70b-versatile) → Genre IDs (300-600ms)
 > **Current**: `llama-3.3-70b-versatile` is the production model.
 > **Watch**: Monitor Groq docs for `openai/gpt-oss-120b` — the newer production king may offer better latency/cost ratio for sub-500ms targets.
 
-#### Gemini 3.1 Flash Lite Preview Stability
+#### Gemini model ladder (latency + reliability)
 
-> **Status**: This model has shown 503 errors in production.
-> **Mitigation**: The hybrid orchestration includes automatic fallback to Gemini-only mode when Preview models fail.
-> **Long-term**: Consider migrating to stable Gemini 2.0 Flash for production reliability.
+> **Order (v1.12.23+)**: Oracle tries **`gemini-2.0-flash` before `gemini-3.1-flash-lite`** for lower typical latency, then continues through additional Gemini 2.x / 1.5 model IDs when needed.
+> **Mitigation**: The ladder handles quota, 404, and transient errors; **OpenRouter** and **TMDB** remain downstream fallbacks when all Gemini candidates fail.
 
 #### Phase 6.14 "Matchmaker" — Technically Unlocked ✅
 

--- a/artifacts/adr-year-in-review.md
+++ b/artifacts/adr-year-in-review.md
@@ -1,0 +1,43 @@
+# ADR: Phase 6.8 — Year in Review (MVP)
+
+## 1. Canonical date logic (hybrid)
+
+**Decision:** The MVP uses `watched_at` when present; otherwise `created_at`. This matches aggregation semantics already used on Profile for “this year” style filters and avoids blocking on a `watched_at` migration.
+
+**Implementation:** `canonicalWatchDate(log)` parses `log.watched_at || log.created_at`. Invalid or missing values exclude the log from year-scoped metrics.
+
+**Context:** A dedicated `watched_at` column UI, migration, and optional backfill are slated for a follow-up release when watch-date editing ships.
+
+**UI:** The Year in Review page includes a short disclaimer: films are grouped by these log dates; manual watch-date editing is coming later.
+
+## 2. Headline count vs rating metrics
+
+**Decision:** The headline **film count** includes every log with `watch_status === 'watched'` whose canonical date falls in the selected calendar year (**rating optional**).
+
+**Decision:** **Average rating** and the **rating distribution histogram** use only logs in that same year scope that have a **finite numeric rating** (same scope subset, filtered for ratings).
+
+**Context:** Keeps the headline inclusive while keeping rating stats meaningful when many logs omit scores.
+
+## 3. Timezone boundary rule
+
+**Decision:** Calendar membership (year and month buckets) uses the **viewer’s local timezone** via standard JavaScript `Date` methods (`getFullYear()`, `getMonth()`) on ISO timestamps returned by Supabase.
+
+**Context:** Low-friction client aggregation; late-night local logs stay in the intended calendar year for most users.
+
+## 4. MVP metric catalog (Tier 1 only)
+
+Included:
+
+- Headline total films (watched in year).
+- Average rating + rating distribution (rated subset only).
+- Top genres (cap 5).
+- Top moods (ordered by count).
+- Monthly watch counts (12 buckets, January–December).
+- Physical collection: count of logs with a non-empty `source_upc`.
+- Reviews written: count of logs with non-empty trimmed `review`.
+
+Excluded from MVP: YoY comparison, share/OG images, longest/shortest runtime, server-side RPC aggregation.
+
+## 5. Implementation shape
+
+**Decision:** Single client fetch of `movie_logs` for the authenticated user; pure functions in `src/utils/yearInReview.js` (`buildYearInReview(year, logs)`) compute all metrics. No Supabase RPC for MVP.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,16 @@ import globals from 'globals';
 
 export default [
   {
+    settings: {
+      react: {
+        version: 'detect',
+      },
+    },
+  },
+  {
     ignores: [
+      'android/**',
+      'public/sw.js',
       'dist/**',
       'node_modules/**',
       'coverage/**',

--- a/index.html
+++ b/index.html
@@ -22,9 +22,6 @@
 
       gtag('config', 'G-V9YRL159CM');
     </script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Creepster&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filmgraph",
-  "version": "1.12.14",
+  "version": "1.12.15",
   "description": "**Your Personal Movie Logging & Visualization Platform**",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filmgraph",
-  "version": "1.12.15",
+  "version": "1.12.21",
   "description": "**Your Personal Movie Logging & Visualization Platform**",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filmgraph",
-  "version": "1.12.21",
+  "version": "1.12.23",
   "description": "**Your Personal Movie Logging & Visualization Platform**",
   "type": "module",
   "scripts": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('')`. */
-    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'https://filmgraph-azure.vercel.app',
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'https://filmgraph.app',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',

--- a/scripts/login-verify.mjs
+++ b/scripts/login-verify.mjs
@@ -1,0 +1,111 @@
+/**
+ * One-off login verification — not part of CI. Run from project root:
+ *   node scripts/login-verify.mjs [baseUrl]
+ */
+import { chromium } from '@playwright/test';
+import dotenv from 'dotenv';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.resolve(__dirname, '../.env') });
+
+const BASE_URL = process.argv[2] || process.env.PLAYWRIGHT_BASE_URL || 'https://filmgraph.app';
+const EMAIL = process.env.TEST_USER_EMAIL;
+const PASSWORD = process.env.TEST_USER_PASSWORD;
+const OUT_DIR = path.resolve(__dirname, '../test-results/login-verify');
+
+async function main() {
+  if (!EMAIL || !PASSWORD) {
+    console.error('FAIL: Missing TEST_USER_EMAIL or TEST_USER_PASSWORD in .env');
+    process.exit(1);
+  }
+
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+
+  const consoleErrors = [];
+  const networkErrors = [];
+  const authResponses = [];
+
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') consoleErrors.push(msg.text());
+  });
+
+  page.on('response', (res) => {
+    const url = res.url();
+    if (url.includes('supabase.co/auth') || url.includes('/auth/v1/')) {
+      authResponses.push({ url, status: res.status() });
+    }
+    if (res.status() >= 400 && (url.includes('supabase') || url.includes('/auth'))) {
+      networkErrors.push({ url, status: res.status() });
+    }
+  });
+
+  const result = {
+    baseUrl: BASE_URL,
+    loginSuccess: false,
+    profileLoaded: false,
+    libraryLoaded: false,
+    finalUrl: null,
+    consoleErrors: [],
+    networkErrors: [],
+    authResponses: [],
+    screenshots: [],
+    error: null,
+  };
+
+  try {
+    await page.goto(`${BASE_URL}/login`, { waitUntil: 'domcontentloaded', timeout: 30000 });
+    await page.screenshot({ path: path.join(OUT_DIR, '01-login-page.png') });
+    result.screenshots.push('01-login-page.png');
+
+    await page.locator('#email, input[type="email"]').first().fill(EMAIL);
+    await page.locator('#password, input[type="password"]').first().fill(PASSWORD);
+    await page.locator('button[type="submit"], .login-button').first().click();
+
+    await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 20000 }).catch(() => {});
+    await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+
+    result.finalUrl = page.url();
+    result.loginSuccess = !page.url().includes('/login');
+    await page.screenshot({ path: path.join(OUT_DIR, '02-after-login.png') });
+    result.screenshots.push('02-after-login.png');
+
+    if (result.loginSuccess) {
+      await page.goto(`${BASE_URL}/profile`, { waitUntil: 'domcontentloaded', timeout: 20000 });
+      await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+      const navVisible = await page.getByRole('navigation').isVisible().catch(() => false);
+      result.profileLoaded = navVisible || !page.url().includes('/login');
+      await page.screenshot({ path: path.join(OUT_DIR, '03-profile.png') });
+      result.screenshots.push('03-profile.png');
+
+      await page.goto(`${BASE_URL}/library`, { waitUntil: 'domcontentloaded', timeout: 20000 });
+      await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+      result.libraryLoaded = !page.url().includes('/login');
+      await page.screenshot({ path: path.join(OUT_DIR, '04-library.png') });
+      result.screenshots.push('04-library.png');
+    }
+  } catch (err) {
+    result.error = err.message;
+    await page.screenshot({ path: path.join(OUT_DIR, '99-error.png') }).catch(() => {});
+    result.screenshots.push('99-error.png');
+  } finally {
+    result.consoleErrors = [...new Set(consoleErrors)].slice(0, 10);
+    result.networkErrors = networkErrors.slice(0, 10);
+    result.authResponses = authResponses;
+    await browser.close();
+  }
+
+  const reportPath = path.join(OUT_DIR, 'report.json');
+  fs.writeFileSync(reportPath, JSON.stringify(result, null, 2));
+
+  console.log(JSON.stringify(result, null, 2));
+  process.exit(result.loginSuccess ? 0 : 1);
+}
+
+main();

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "skills": {
+    "supabase": {
+      "source": "supabase/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/supabase/SKILL.md",
+      "computedHash": "5e179217b674b2c9617e54b09578b1119a315c784c22a9f22d940926de082d87"
+    },
+    "supabase-postgres-best-practices": {
+      "source": "supabase/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/supabase-postgres-best-practices/SKILL.md",
+      "computedHash": "8e41c7417894e6f394614ee7ca3ee5322b1e58d890255d441f42dea98732597f"
+    }
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -37,6 +37,7 @@ const DiscoveryPage = lazy(() => import("./pages/DiscoveryPage"));
 const MatchmakerPage = lazy(() => import("./pages/MatchmakerPage"));
 const SynergyDashboard = lazy(() => import("./pages/SynergyDashboard"));
 const OracleAnalyticsPage = lazy(() => import("./pages/OracleAnalyticsPage"));
+const YearInReviewPage = lazy(() => import("./pages/YearInReviewPage"));
 
 // ============================================
 // HEADER - SOLID SEARCH SYSTEM (NO MORE BUGS)
@@ -448,6 +449,22 @@ function AppContent() {
                 element={
                   <ProtectedRoute>
                     <ProfilePage />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/year-in-review"
+                element={
+                  <ProtectedRoute>
+                    <YearInReviewPage />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/year-in-review/:year"
+                element={
+                  <ProtectedRoute>
+                    <YearInReviewPage />
                   </ProtectedRoute>
                 }
               />

--- a/src/api/sharedLists.js
+++ b/src/api/sharedLists.js
@@ -456,7 +456,7 @@ export async function addMovieToList(listId, tmdbId, userId, movie = {}) {
   let { data, error } = await supabase.from('list_items').insert(row).select().single();
 
   if (error && isAddedByColumnError(error)) {
-    const { added_by, ...fallbackRow } = row;
+    const { added_by: _addedBy, ...fallbackRow } = row;
     const fallbackInsert = await supabase
       .from('list_items')
       .insert(fallbackRow)

--- a/src/components/AddToListButton.css
+++ b/src/components/AddToListButton.css
@@ -97,7 +97,6 @@
 .add-to-list-dropdown {
   position: absolute;
   top: calc(100% + 8px);
-  right: 0;
   width: 300px;
   max-height: 400px;
   background-color: #1a1a1a;
@@ -107,6 +106,16 @@
   z-index: 1000;
   overflow: hidden;
   animation: dropdownFadeIn 0.2s ease-out;
+}
+
+.add-to-list-dropdown--start {
+  left: 0;
+  right: auto;
+}
+
+.add-to-list-dropdown--end {
+  right: 0;
+  left: auto;
 }
 
 @keyframes dropdownFadeIn {
@@ -335,7 +344,9 @@
 
 /* Responsive adjustments */
 @media (max-width: 640px) {
-  .add-to-list-dropdown {
+  .add-to-list-dropdown,
+  .add-to-list-dropdown--start,
+  .add-to-list-dropdown--end {
     right: 0;
     left: auto;
     width: min(280px, calc(100vw - 32px));

--- a/src/components/AddToListButton.css
+++ b/src/components/AddToListButton.css
@@ -336,7 +336,9 @@
 /* Responsive adjustments */
 @media (max-width: 640px) {
   .add-to-list-dropdown {
-    right: -16px;
-    width: 280px;
+    right: 0;
+    left: auto;
+    width: min(280px, calc(100vw - 32px));
+    max-width: calc(100vw - 24px);
   }
 }

--- a/src/components/AddToListButton.jsx
+++ b/src/components/AddToListButton.jsx
@@ -24,6 +24,7 @@ function AddToListButton({ movie, className = '', variant = 'default' }) {
   } = useLists();
   const toast = useToast();
   const [isOpen, setIsOpen] = useState(false);
+  const [dropdownPlacement, setDropdownPlacement] = useState('end');
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [isAdding, setIsAdding] = useState(null); // tmdb_id of movie being added
   const dropdownRef = useRef(null);
@@ -41,6 +42,41 @@ function AddToListButton({ movie, className = '', variant = 'default' }) {
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
+
+  useEffect(() => {
+    if (!isOpen || !dropdownRef.current) return;
+
+    const updatePlacement = () => {
+      if (!dropdownRef.current) return;
+
+      const rect = dropdownRef.current.getBoundingClientRect();
+      const viewportWidth = window.innerWidth || document.documentElement.clientWidth;
+      const horizontalPadding = 12;
+      const preferredWidth = 300;
+      const maxAllowed = Math.max(220, viewportWidth - horizontalPadding * 2);
+      const dropdownWidth = Math.min(preferredWidth, maxAllowed);
+
+      const spaceIfStart = viewportWidth - rect.left - horizontalPadding;
+      const spaceIfEnd = rect.right - horizontalPadding;
+
+      if (spaceIfStart >= dropdownWidth) {
+        setDropdownPlacement('start');
+      } else if (spaceIfEnd >= dropdownWidth) {
+        setDropdownPlacement('end');
+      } else {
+        setDropdownPlacement(spaceIfStart >= spaceIfEnd ? 'start' : 'end');
+      }
+    };
+
+    updatePlacement();
+    window.addEventListener('resize', updatePlacement);
+    window.addEventListener('scroll', updatePlacement, true);
+
+    return () => {
+      window.removeEventListener('resize', updatePlacement);
+      window.removeEventListener('scroll', updatePlacement, true);
+    };
+  }, [isOpen]);
 
   const handleToggleDropdown = () => {
     if (!isAuthenticated) return;
@@ -142,7 +178,7 @@ function AddToListButton({ movie, className = '', variant = 'default' }) {
         )}
 
         {isOpen && (
-          <div className="add-to-list-dropdown">
+          <div className={`add-to-list-dropdown add-to-list-dropdown--${dropdownPlacement}`}>
             {isLoading ? (
               <div className="add-to-list-loading">
                 <div className="loading-spinner"></div>

--- a/src/components/AddToListButton.jsx
+++ b/src/components/AddToListButton.jsx
@@ -102,10 +102,18 @@ function AddToListButton({ movie, className = '', variant = 'default' }) {
             disabled={isLoading}
             aria-expanded={isOpen}
             aria-haspopup="true"
+            aria-label={
+              existingLists.length > 0
+                ? `Add to another list — already in ${existingLists.length}`
+                : 'Add to a list'
+            }
             title={existingLists.length > 0 ? `In ${existingLists.length} list(s)` : 'Add to list'}
           >
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <path d="M12 5v14M5 12h14" />
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+              <circle cx="4" cy="6" r="1.5" fill="currentColor" stroke="none" />
+              <circle cx="4" cy="12" r="1.5" fill="currentColor" stroke="none" />
+              <circle cx="4" cy="18" r="1.5" fill="currentColor" stroke="none" />
+              <path strokeLinecap="round" d="M9 6h11M9 12h11M9 18h8" />
             </svg>
             {existingLists.length > 0 && (
               <span className="add-to-list-badge">{existingLists.length}</span>
@@ -120,8 +128,11 @@ function AddToListButton({ movie, className = '', variant = 'default' }) {
             aria-haspopup="true"
             title={existingLists.length > 0 ? `In ${existingLists.length} list(s)` : 'Add to list'}
           >
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <path d="M12 5v14M5 12h14" />
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+              <circle cx="4" cy="6" r="1.5" fill="currentColor" stroke="none" />
+              <circle cx="4" cy="12" r="1.5" fill="currentColor" stroke="none" />
+              <circle cx="4" cy="18" r="1.5" fill="currentColor" stroke="none" />
+              <path strokeLinecap="round" d="M9 6h11M9 12h11M9 18h8" />
             </svg>
             <span>Add to List</span>
             {existingLists.length > 0 && (

--- a/src/components/ArchiveImporterModal.jsx
+++ b/src/components/ArchiveImporterModal.jsx
@@ -160,7 +160,7 @@ function ArchiveImporterModal({ onClose, onImportComplete }) {
         };
 
         if (listError && isAddedByColumnError(listError)) {
-          const fallbackItems = listItemsToAdd.map(({ added_by, ...item }) => item);
+          const fallbackItems = listItemsToAdd.map(({ added_by: _addedBy, ...item }) => item);
           const fallback = await supabase
             .from('list_items')
             .upsert(fallbackItems, {

--- a/src/components/LibraryAdvancedFilters.css
+++ b/src/components/LibraryAdvancedFilters.css
@@ -1,0 +1,178 @@
+.library-advanced-details {
+  grid-column: 1 / -1;
+  margin-top: 0.25rem;
+  border-top: 1px solid #27272a;
+  padding-top: 0.85rem;
+}
+
+.library-advanced-summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.35rem 0.75rem;
+  cursor: pointer;
+  list-style: none;
+  font-size: 0.8125rem;
+  color: #a1a1aa;
+}
+
+.library-advanced-summary::-webkit-details-marker {
+  display: none;
+}
+
+.library-advanced-summary-title {
+  font-weight: 700;
+  color: #fafafa;
+}
+
+.library-advanced-summary-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.75rem;
+  color: #71717a;
+}
+
+.library-advanced-active-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #f97316;
+  flex-shrink: 0;
+}
+
+.library-advanced-body {
+  margin-top: 0.85rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.library-advanced-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.library-advanced-block-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.library-advanced-segment {
+  display: inline-flex;
+  border-radius: 8px;
+  border: 1px solid #3f3f46;
+  overflow: hidden;
+}
+
+.library-advanced-segment-btn {
+  padding: 0.35rem 0.65rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #a1a1aa;
+  background: #18181b;
+  border: none;
+  cursor: pointer;
+  min-height: 44px;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.library-advanced-segment-btn--active {
+  background: rgba(249, 115, 22, 0.18);
+  color: #fdba74;
+}
+
+.library-advanced-mood-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.library-advanced-hint {
+  margin: 0;
+  font-size: 0.72rem;
+  line-height: 1.45;
+  color: #52525b;
+}
+
+.library-advanced-empty {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.45;
+  color: #71717a;
+}
+
+.library-advanced-genre-scroll {
+  max-height: 160px;
+  overflow-y: auto;
+  padding: 0.35rem 0.25rem;
+  border: 1px solid #27272a;
+  border-radius: 10px;
+  background: #0f0f11;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.library-advanced-genre-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.5rem;
+  border-radius: 8px;
+  font-size: 0.8125rem;
+  color: #e4e4e7;
+  cursor: pointer;
+  min-height: 44px;
+  box-sizing: border-box;
+}
+
+.library-advanced-genre-item:hover {
+  background: rgba(63, 63, 70, 0.35);
+}
+
+.library-advanced-genre-item input {
+  width: 1rem;
+  height: 1rem;
+  accent-color: #ea580c;
+}
+
+.library-advanced-rating-row {
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 0.75rem 1rem;
+}
+
+.library-advanced-rating-field {
+  flex: 1;
+  min-width: min(160px, 100%);
+}
+
+.library-advanced-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.library-advanced-clear-btn {
+  padding: 0.55rem 0.85rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: #fdba74;
+  background: transparent;
+  border: 1px solid #52525b;
+  border-radius: 10px;
+  cursor: pointer;
+  min-height: 44px;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.library-advanced-clear-btn:hover {
+  border-color: #f97316;
+  background: rgba(249, 115, 22, 0.08);
+}

--- a/src/components/LibraryAdvancedFilters.jsx
+++ b/src/components/LibraryAdvancedFilters.jsx
@@ -1,0 +1,156 @@
+import MoodChip, { MOODS } from './MoodChip';
+import './LibraryAdvancedFilters.css';
+
+function LibraryAdvancedFilters({
+  selectedMoods,
+  onMoodsChange,
+  moodMatchMode,
+  onMoodMatchModeChange,
+  genreOptions,
+  selectedGenres,
+  onToggleGenre,
+  minRating,
+  maxRating,
+  onMinRatingChange,
+  onMaxRatingChange,
+  onClearAdvanced,
+}) {
+  const hasAdvancedActive =
+    selectedMoods.length > 0 ||
+    selectedGenres.length > 0 ||
+    minRating !== '' ||
+    maxRating !== '';
+
+  const handleMoodToggle = (moodId) => {
+    if (!onMoodsChange) return;
+    if (selectedMoods.includes(moodId)) {
+      onMoodsChange(selectedMoods.filter((id) => id !== moodId));
+    } else {
+      onMoodsChange([...selectedMoods, moodId]);
+    }
+  };
+
+  return (
+    <details className="library-advanced-details">
+      <summary className="library-advanced-summary">
+        <span className="library-advanced-summary-title">Advanced search</span>
+        <span className="library-advanced-summary-meta">
+          Mood · genre · your rating
+          {hasAdvancedActive ? (
+            <span className="library-advanced-active-dot" aria-hidden />
+          ) : null}
+        </span>
+      </summary>
+
+      <div className="library-advanced-body">
+        <div className="library-advanced-block">
+          <div className="library-advanced-block-header">
+            <span className="library-filter-label">Mood</span>
+            {selectedMoods.length > 1 && (
+              <div className="library-advanced-segment" role="group" aria-label="Mood match mode">
+                <button
+                  type="button"
+                  className={`library-advanced-segment-btn ${moodMatchMode === 'any' ? 'library-advanced-segment-btn--active' : ''}`}
+                  onClick={() => onMoodMatchModeChange('any')}
+                >
+                  Any
+                </button>
+                <button
+                  type="button"
+                  className={`library-advanced-segment-btn ${moodMatchMode === 'all' ? 'library-advanced-segment-btn--active' : ''}`}
+                  onClick={() => onMoodMatchModeChange('all')}
+                >
+                  All
+                </button>
+              </div>
+            )}
+          </div>
+          <div className="library-advanced-mood-grid">
+            {MOODS.map((m) => (
+              <MoodChip
+                key={m.id}
+                moodId={m.id}
+                isSelected={selectedMoods.includes(m.id)}
+                onToggle={handleMoodToggle}
+                size="small"
+              />
+            ))}
+          </div>
+          <p className="library-advanced-hint">
+            Uses your log moods. Choose one or stack several; “All” requires every selected mood on the same log.
+          </p>
+        </div>
+
+        <div className="library-advanced-block">
+          <span className="library-filter-label">Genre</span>
+          {genreOptions.length === 0 ? (
+            <p className="library-advanced-empty">
+              No genres on your logs yet — genres are saved when you log from TMDB. Older imports may be missing them.
+            </p>
+          ) : (
+            <div className="library-advanced-genre-scroll" role="group" aria-label="Filter by genre">
+              {genreOptions.map((g) => (
+                <label key={g} className="library-advanced-genre-item">
+                  <input
+                    type="checkbox"
+                    checked={selectedGenres.includes(g)}
+                    onChange={() => onToggleGenre(g)}
+                  />
+                  <span>{g}</span>
+                </label>
+              ))}
+            </div>
+          )}
+          <p className="library-advanced-hint">
+            Logs must include every genre you select (best for narrowing).
+          </p>
+        </div>
+
+        <div className="library-advanced-block library-advanced-rating-row">
+          <div className="library-advanced-rating-field">
+            <label htmlFor="library-min-rating" className="library-filter-label">
+              Min rating
+            </label>
+            <input
+              id="library-min-rating"
+              type="number"
+              className="library-input"
+              min={0}
+              max={5}
+              step={0.5}
+              placeholder="Any"
+              value={minRating}
+              onChange={(e) => onMinRatingChange(e.target.value)}
+            />
+          </div>
+          <div className="library-advanced-rating-field">
+            <label htmlFor="library-max-rating" className="library-filter-label">
+              Max rating
+            </label>
+            <input
+              id="library-max-rating"
+              type="number"
+              className="library-input"
+              min={0}
+              max={5}
+              step={0.5}
+              placeholder="Any"
+              value={maxRating}
+              onChange={(e) => onMaxRatingChange(e.target.value)}
+            />
+          </div>
+        </div>
+
+        {hasAdvancedActive && (
+          <div className="library-advanced-actions">
+            <button type="button" className="library-advanced-clear-btn" onClick={onClearAdvanced}>
+              Clear advanced filters
+            </button>
+          </div>
+        )}
+      </div>
+    </details>
+  );
+}
+
+export default LibraryAdvancedFilters;

--- a/src/components/MovieCard.jsx
+++ b/src/components/MovieCard.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import LogMovieModal from './LogMovieModal';
 import AddToListButton from './AddToListButton';
+import { useToast } from '../context/ToastContext';
 import './MovieCard.css';
 
 function MovieCard({
@@ -12,6 +13,7 @@ function MovieCard({
   onDelete,
 }) {
   const navigate = useNavigate();
+  const toast = useToast();
   const [showModal, setShowModal] = useState(false);
 
   const handleCardClick = () => {
@@ -220,7 +222,10 @@ function MovieCard({
         <LogMovieModal
           movie={movie}
           onClose={() => setShowModal(false)}
-          onLogged={() => setShowModal(false)}
+          onSaved={() => {
+            setShowModal(false);
+            toast.success(`"${movie.title}" logged successfully!`);
+          }}
         />
       )}
     </>

--- a/src/components/Oracle/ResultCard.jsx
+++ b/src/components/Oracle/ResultCard.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { memo, useCallback, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 
 function ProviderLogos({ logos }) {
@@ -43,6 +43,66 @@ function ResultCard({
   onRerollAll,
 }) {
   const [isListDropdownOpen, setIsListDropdownOpen] = useState(false);
+  const addToListInFlightRef = useRef(new Set());
+  const perfDebugEnabled =
+    String(import.meta.env.VITE_FEATURE_ORACLE_PERF_DEBUG || "").toLowerCase() === "true";
+  const renderCountRef = useRef(0);
+  renderCountRef.current += 1;
+
+  const listOptions = useMemo(
+    () =>
+      lists.map((list) => ({
+        ...list,
+        isInList: isMovieInList(list.id, movieTmdb?.id),
+        isReadOnly: !canEditList(list.id),
+      })),
+    [canEditList, isMovieInList, lists, movieTmdb?.id]
+  );
+
+  const handleOpenWatched = useCallback(() => {
+    if (movieTmdb) onOpenWatchedModal(movieTmdb);
+  }, [movieTmdb, onOpenWatchedModal]);
+
+  const handleAddWatchlist = useCallback(() => {
+    onAddToWatchlist(movieTmdb);
+  }, [movieTmdb, onAddToWatchlist]);
+
+  const handleToggleListDropdown = useCallback(() => {
+    setIsListDropdownOpen((open) => !open);
+  }, []);
+
+  const handleRerollOne = useCallback(() => {
+    onRerollOne(movieTmdb?.id, rec.title, rec.year);
+  }, [movieTmdb?.id, onRerollOne, rec.title, rec.year]);
+
+  const handleAddToList = useCallback(
+    async (list) => {
+      if (!movieTmdb?.id || list.isInList || list.isReadOnly) return;
+      const inFlightKey = `${list.id}:${movieTmdb.id}`;
+      if (addToListInFlightRef.current.has(inFlightKey)) return;
+
+      addToListInFlightRef.current.add(inFlightKey);
+      try {
+        await addMovieToList(list.id, {
+          tmdb_id: movieTmdb.id,
+          title: movieTmdb.title,
+          poster_path: movieTmdb.poster_path,
+        });
+        toast.success(`Added to ${list.name}`);
+        setIsListDropdownOpen(false);
+      } catch (err) {
+        console.error("Add to list error:", err);
+        toast.error(err.message?.includes("duplicate") ? "Already in this list" : "Failed to add to list");
+      } finally {
+        addToListInFlightRef.current.delete(inFlightKey);
+      }
+    },
+    [addMovieToList, movieTmdb?.id, movieTmdb?.poster_path, movieTmdb?.title, toast]
+  );
+
+  if (perfDebugEnabled && renderCountRef.current % 10 === 0) {
+    console.log(`[OraclePerf] ResultCard(${rec.title}) render count=${renderCountRef.current}`);
+  }
 
   return (
     <div
@@ -123,7 +183,7 @@ function ResultCard({
             </a>
           )}
 
-          <button onClick={() => movieTmdb && onOpenWatchedModal(movieTmdb)} className="lib-action-btn">
+          <button onClick={handleOpenWatched} className="lib-action-btn">
             <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
               <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
               <polyline points="22 4 12 14.01 9 11.01" />
@@ -131,7 +191,7 @@ function ResultCard({
             Watched
           </button>
 
-          <button onClick={() => onAddToWatchlist(movieTmdb)} className="lib-action-btn">
+          <button onClick={handleAddWatchlist} className="lib-action-btn">
             <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
               <path d="M12 5v14M5 12h14" />
             </svg>
@@ -140,7 +200,7 @@ function ResultCard({
 
           <div className="relative" style={{ zIndex: 100 }}>
             <button
-              onClick={() => setIsListDropdownOpen((open) => !open)}
+              onClick={handleToggleListDropdown}
               className="lib-action-btn"
               disabled={lists.length === 0}
             >
@@ -153,34 +213,16 @@ function ResultCard({
             </button>
             {isListDropdownOpen && lists.length > 0 && (
               <div className="list-dropdown" style={{ right: 0, overflow: "visible", zIndex: 9999 }}>
-                {lists.map((list) => {
-                  const isInList = isMovieInList(list.id, movieTmdb?.id);
-                  const isReadOnly = !canEditList(list.id);
+                {listOptions.map((list) => {
                   return (
                     <button
                       key={list.id}
-                      onClick={async () => {
-                        if (!movieTmdb?.id || isInList || isReadOnly) return;
-                        try {
-                          await addMovieToList(list.id, {
-                            tmdb_id: movieTmdb.id,
-                            title: movieTmdb.title,
-                            poster_path: movieTmdb.poster_path,
-                          });
-                          toast.success(`Added to ${list.name}`);
-                          setIsListDropdownOpen(false);
-                        } catch (err) {
-                          console.error("Add to list error:", err);
-                          toast.error(
-                            err.message?.includes("duplicate") ? "Already in this list" : "Failed to add to list"
-                          );
-                        }
-                      }}
+                      onClick={() => handleAddToList(list)}
                       className="list-dropdown-item"
-                      disabled={isInList || isReadOnly}
+                      disabled={list.isInList || list.isReadOnly}
                     >
                       {list.name}
-                      {isInList ? " • Added" : isReadOnly ? " • Viewer" : ""}
+                      {list.isInList ? " • Added" : list.isReadOnly ? " • Viewer" : ""}
                     </button>
                   );
                 })}
@@ -190,7 +232,7 @@ function ResultCard({
 
           <button
             className="reject-reroll-btn"
-            onClick={() => onRerollOne(movieTmdb?.id, rec.title, rec.year)}
+            onClick={handleRerollOne}
             disabled={isDiscovering}
             title="Replace only this recommendation"
           >
@@ -215,4 +257,4 @@ function ResultCard({
   );
 }
 
-export default ResultCard;
+export default memo(ResultCard);

--- a/src/components/QuickMovieActions.jsx
+++ b/src/components/QuickMovieActions.jsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useUser } from "../context/UserContext";
+import { useToast } from "../context/ToastContext";
 import AddToListButton from "./AddToListButton";
 import LogMovieModal from "./LogMovieModal";
 import "./QuickMovieActions.css";
@@ -14,6 +15,7 @@ function normalizePosterPath(movie) {
 
 function QuickMovieActions({ movie, className = "" }) {
   const { isAuthenticated } = useUser();
+  const toast = useToast();
   const [showModal, setShowModal] = useState(false);
 
   if (!isAuthenticated) return null;
@@ -38,10 +40,12 @@ function QuickMovieActions({ movie, className = "" }) {
             event.stopPropagation();
             setShowModal(true);
           }}
-          title="Log Movie"
+          title="Log this film"
+          aria-label="Log this film"
         >
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-            <path d="M12 5v14M5 12h14" />
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+            <path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7" />
+            <path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z" />
           </svg>
         </button>
       </div>
@@ -50,7 +54,10 @@ function QuickMovieActions({ movie, className = "" }) {
         <LogMovieModal
           movie={normalizedMovie}
           onClose={() => setShowModal(false)}
-          onLogged={() => setShowModal(false)}
+          onSaved={() => {
+            setShowModal(false);
+            toast.success(`"${normalizedMovie.title}" logged successfully!`);
+          }}
         />
       )}
     </>

--- a/src/components/SearchResults.css
+++ b/src/components/SearchResults.css
@@ -46,7 +46,7 @@
 .movie-card {
   background: #121212;
   border-radius: 12px;
-  overflow: hidden;
+  overflow: visible;
   transition: transform 0.2s ease;
   display: flex;
   flex-direction: column;
@@ -57,6 +57,14 @@
   position: relative;
   padding-top: 150%;
   background: #1a1a1a;
+  overflow: visible;
+}
+
+.movie-card-poster-clip {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  border-radius: 12px 12px 0 0;
 }
 
 .search-card-quick-actions {
@@ -66,7 +74,7 @@
   z-index: 3;
 }
 
-.movie-card-poster img {
+.movie-card-poster-clip img {
   position: absolute;
   top: 0;
   left: 0;

--- a/src/components/SearchResults.jsx
+++ b/src/components/SearchResults.jsx
@@ -63,11 +63,13 @@ function SearchResults({ movies }) {
             >
               <div className="movie-card">
                 <div className="movie-card-poster">
-                  <img
-                    src={item.Poster}
-                    alt={`${item.Title} poster`}
-                    loading="lazy"
-                  />
+                  <div className="movie-card-poster-clip">
+                    <img
+                      src={item.Poster}
+                      alt={`${item.Title} poster`}
+                      loading="lazy"
+                    />
+                  </div>
                   <div
                     className="search-card-quick-actions"
                     onClick={(event) => event.stopPropagation()}

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,7 +4,7 @@
  */
 
 // Application Version
-export const APP_VERSION = '1.12.14';
+export const APP_VERSION = '1.12.15';
 
 // Theme Colors
 export const THEME_COLORS = {

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,7 +4,7 @@
  */
 
 // Application Version
-export const APP_VERSION = '1.12.15';
+export const APP_VERSION = '1.12.21';
 
 // Theme Colors
 export const THEME_COLORS = {

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,7 +4,7 @@
  */
 
 // Application Version
-export const APP_VERSION = '1.12.21';
+export const APP_VERSION = '1.12.23';
 
 // Theme Colors
 export const THEME_COLORS = {

--- a/src/context/OracleContext.jsx
+++ b/src/context/OracleContext.jsx
@@ -1,16 +1,26 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { useUser } from "./UserContext";
 import { getSupabase } from "../supabaseClient";
 import { getHybridRecommendation, BASE_SYSTEM_PROMPT } from "../utils/gemini";
 import { canUseOracle, recordOracleUse } from "../utils/oracleBudget";
+import { parseOracleIntentWithGroq } from "../utils/groq";
+import { buildTasteContextString, buildUserTasteProfile } from "../utils/oracleTasteProfile";
+import { resolveOracleQueryConstraints } from "../utils/oracleQueryConstraints";
 import {
   buildOracleEventPayload,
   classifyOracleError,
   trackOracleProviderEventSafe,
 } from "../utils/oracleAnalytics";
+import { isAbortLikeError } from "../utils/oracleReliability";
 import { fetchTMDBMovie, fetchWatchProviders } from "../api/tmdb";
 
 const OracleContext = createContext(null);
+const ORACLE_QUERY_CONSTRAINTS_ENABLED =
+  String(import.meta.env.VITE_FEATURE_ORACLE_QUERY_CONSTRAINTS || "").toLowerCase() === "true";
+const ORACLE_GROQ_INTENT_PARSER_ENABLED =
+  String(import.meta.env.VITE_FEATURE_ORACLE_GROQ_INTENT_PARSER || "").toLowerCase() === "true";
+const ORACLE_TASTE_RPC_ENABLED =
+  String(import.meta.env.VITE_FEATURE_ORACLE_TASTE_RPC || "").toLowerCase() === "true";
 
 const toKey = (title, year) => `${String(title || "").trim().toLowerCase()}::${String(year || "").trim()}`;
 
@@ -70,9 +80,50 @@ export function OracleProvider({ children }) {
   const [tmdbResults, setTmdbResults] = useState([]);
   const [providerResults, setProviderResults] = useState([]);
   const [error, setError] = useState("");
-  const [rejectedIds, setRejectedIds] = useState([]);
   const [rejectedTitles, setRejectedTitles] = useState([]);
   const [selectedProviderIds, setSelectedProviderIds] = useState([]);
+  const [historyCache, setHistoryCache] = useState({
+    fingerprint: "",
+    logs: [],
+    recentToWatch: [],
+    listItems: [],
+  });
+  const activeRequestRef = useRef({
+    requestId: 0,
+    controller: null,
+  });
+  const queryConstraintsCacheRef = useRef(new Map());
+  const historyFetchCacheRef = useRef({ key: "", expiresAt: 0, value: null });
+
+  const beginOracleRequest = useCallback(() => {
+    if (activeRequestRef.current.controller) {
+      activeRequestRef.current.controller.abort("superseded");
+    }
+    const controller = new AbortController();
+    const requestId = activeRequestRef.current.requestId + 1;
+    activeRequestRef.current = { requestId, controller };
+    return { requestId, signal: controller.signal };
+  }, []);
+
+  const isCurrentRequest = useCallback(
+    (requestId) => activeRequestRef.current.requestId === requestId,
+    []
+  );
+
+  useEffect(
+    () => () => {
+      if (activeRequestRef.current.controller) {
+        activeRequestRef.current.controller.abort("unmount");
+      }
+    },
+    []
+  );
+
+  const memoizedTasteProfile = useMemo(
+    () => buildUserTasteProfile(historyCache.logs, historyCache.recentToWatch, historyCache.listItems),
+    [historyCache.listItems, historyCache.logs, historyCache.recentToWatch]
+  );
+  const memoizedTasteContext = useMemo(() => buildTasteContextString(memoizedTasteProfile), [memoizedTasteProfile]);
 
   useEffect(() => {
     const fetchProviderPreferences = async () => {
@@ -114,11 +165,57 @@ export function OracleProvider({ children }) {
 
   const fetchUserMovieHistory = useCallback(async () => {
     if (!user?.id) return { allKnownTitles: [], userTasteContext: "" };
+    const cacheKey = `${user.id}:${ORACLE_TASTE_RPC_ENABLED ? "rpc" : "local"}`;
+    const now = Date.now();
+    if (historyFetchCacheRef.current.key === cacheKey && historyFetchCacheRef.current.expiresAt > now) {
+      return historyFetchCacheRef.current.value;
+    }
+
+    try {
+      const supabase = getSupabase();
+      const [logTitlesResult, listItemsResult, tasteProfileRpcResult] = await Promise.all([
+        supabase.from("movie_logs").select("title").eq("user_id", user.id),
+        supabase.from("list_items").select("title, lists!inner(user_id)").eq("lists.user_id", user.id),
+        ORACLE_TASTE_RPC_ENABLED
+          ? supabase.rpc("get_oracle_taste_profile", { p_user_id: user.id })
+          : Promise.resolve({ data: null, error: null }),
+      ]);
+
+      const listItems = listItemsResult.data || [];
+      const allKnownTitles = [
+        ...new Set([...(logTitlesResult.data || []).map((l) => l.title), ...listItems.map((i) => i.title)]),
+      ];
+      if (tasteProfileRpcResult.error) {
+        throw tasteProfileRpcResult.error;
+      }
+      const rpcPayload = tasteProfileRpcResult.data;
+      if (rpcPayload?.contextString && typeof rpcPayload.contextString === "string") {
+        const value = { allKnownTitles, userTasteContext: rpcPayload.contextString };
+        historyFetchCacheRef.current = { key: cacheKey, expiresAt: Date.now() + 10000, value };
+        return value;
+      }
+      if (rpcPayload?.summary) {
+        const value = {
+          allKnownTitles,
+          userTasteContext: buildTasteContextString(rpcPayload),
+        };
+        historyFetchCacheRef.current = { key: cacheKey, expiresAt: Date.now() + 10000, value };
+        return value;
+      }
+      if (ORACLE_TASTE_RPC_ENABLED) {
+        throw new Error("Oracle taste profile RPC returned empty payload.");
+      }
+    } catch (rpcHistoryErr) {
+      console.warn("Oracle taste profile RPC unavailable; falling back to local builder.", rpcHistoryErr);
+    }
 
     try {
       const supabase = getSupabase();
       const [watchedResult, recentToWatchResult, listItemsResult] = await Promise.all([
-        supabase.from("movie_logs").select("title, watch_status, rating").eq("user_id", user.id),
+        supabase
+          .from("movie_logs")
+          .select("title, watch_status, rating, moods, genres, year, created_at")
+          .eq("user_id", user.id),
         supabase
           .from("movie_logs")
           .select("title, created_at")
@@ -132,30 +229,53 @@ export function OracleProvider({ children }) {
       const logs = watchedResult.data || [];
       const recentToWatch = recentToWatchResult.data || [];
       const listItems = listItemsResult.data || [];
+      const historyFingerprint = JSON.stringify({
+        logs: logs.map(
+          (entry) =>
+            `${entry.title || ""}|${entry.rating || ""}|${entry.watch_status || ""}|${entry.created_at || ""}`
+        ),
+        recentToWatch: recentToWatch.map((entry) => `${entry.title || ""}|${entry.created_at || ""}`),
+        listItems: listItems.map((entry) => String(entry.title || "")),
+      });
 
       const allKnownTitles = [...new Set([...logs.map((l) => l.title), ...listItems.map((i) => i.title)])];
+      if (historyFingerprint === historyCache.fingerprint) {
+        const value = { allKnownTitles, userTasteContext: memoizedTasteContext };
+        historyFetchCacheRef.current = { key: cacheKey, expiresAt: Date.now() + 10000, value };
+        return value;
+      }
+      const tasteProfile = buildUserTasteProfile(logs, recentToWatch, listItems);
+      const userTasteContext = buildTasteContextString(tasteProfile);
+      setHistoryCache({
+        fingerprint: historyFingerprint,
+        logs,
+        recentToWatch,
+        listItems,
+      });
 
-      const positiveWatched = logs
-        .filter((l) => l.watch_status === "watched" && (l.rating >= 4 || !l.rating))
-        .slice(0, 20)
-        .map((l) => l.title);
-      const curatedTitles = listItems.map((i) => i.title);
-      const recentToWatchTitles = recentToWatch.map((m) => m.title).filter(Boolean);
-
-      const tasteProfile = [...new Set([...positiveWatched, ...recentToWatchTitles, ...curatedTitles])];
-      const userTasteContext =
-        tasteProfile.length > 0
-          ? `TopWatched20: ${positiveWatched.join(", ")}\nLastToWatch5: ${recentToWatchTitles.join(", ")}\nCuratedLists: ${curatedTitles
-              .slice(0, 20)
-              .join(", ")}`
-          : "No history found.";
-
-      return { allKnownTitles, userTasteContext };
+      const value = { allKnownTitles, userTasteContext };
+      historyFetchCacheRef.current = { key: cacheKey, expiresAt: Date.now() + 10000, value };
+      return value;
     } catch (historyErr) {
       console.error("Oracle Memory Fetch Error:", historyErr);
       return { allKnownTitles: [], userTasteContext: "" };
     }
-  }, [user?.id]);
+  }, [historyCache.fingerprint, memoizedTasteContext, user?.id]);
+
+  const getResolvedQueryConstraints = useCallback(async (prompt) => {
+    if (!ORACLE_QUERY_CONSTRAINTS_ENABLED) return null;
+    const normalizedPrompt = String(prompt || "").trim().toLowerCase();
+    if (queryConstraintsCacheRef.current.has(normalizedPrompt)) {
+      return queryConstraintsCacheRef.current.get(normalizedPrompt);
+    }
+    const resolved = await resolveOracleQueryConstraints(prompt, {
+      constraintsEnabled: ORACLE_QUERY_CONSTRAINTS_ENABLED,
+      groqIntentEnabled: ORACLE_GROQ_INTENT_PARSER_ENABLED,
+      groqIntentParser: parseOracleIntentWithGroq,
+    });
+    queryConstraintsCacheRef.current.set(normalizedPrompt, resolved);
+    return resolved;
+  }, []);
 
   const enrichRecommendationsWithTmdb = useCallback(
     async (recs) => {
@@ -182,6 +302,7 @@ export function OracleProvider({ children }) {
   const handleDiscover = useCallback(
     async (_additionalRejectedIds = [], additionalRejectedTitles = [], requestSource = "discover") => {
       if (!tempPrompt.trim()) return;
+      const { requestId, signal } = beginOracleRequest();
 
       setIsDiscovering(true);
       setError("");
@@ -203,18 +324,23 @@ export function OracleProvider({ children }) {
         const allRejectedTitles = [
           ...new Set([...rejectedTitles, ...additionalRejectedTitles, ...allKnownTitles]),
         ];
+        const queryConstraints = await getResolvedQueryConstraints(tempPrompt);
 
         const aiResponse = await getHybridRecommendation(tempPrompt, {
           userContext: userTasteContext,
           systemPrompt: BASE_SYSTEM_PROMPT,
           rejectedTitles: allRejectedTitles,
+          queryConstraints,
+          signal,
         });
+        if (!isCurrentRequest(requestId)) return;
         orchestrationMeta = aiResponse?._meta || null;
         if (!aiResponse?.recommendations?.length) {
           throw new Error("The Oracle is silent. Please try again.");
         }
 
         const { mappedTmdb, providerResponses } = await enrichRecommendationsWithTmdb(aiResponse.recommendations);
+        if (!isCurrentRequest(requestId)) return;
         setRecommendations(aiResponse.recommendations);
         setTmdbResults(mappedTmdb);
         setProviderResults(providerResponses);
@@ -236,12 +362,16 @@ export function OracleProvider({ children }) {
           );
         }
       } catch (discoverErr) {
+        if (isAbortLikeError(discoverErr) || !isCurrentRequest(requestId)) {
+          return;
+        }
         console.error("Discovery error:", discoverErr);
         setError(getDiscoveryErrorMessage(discoverErr));
 
         if (user?.id) {
           const promptType = selectedMood?.prompt === tempPrompt ? "mood_preset" : "custom_prompt";
-          const { errorCode, fallbackReason, provider, statusCode } = classifyOracleError(discoverErr);
+          const { errorCode, fallbackReason, provider, statusCode, failureBucket, failureStage } =
+            classifyOracleError(discoverErr);
           trackOracleProviderEventSafe(
             buildOracleEventPayload({
               userId: user.id,
@@ -249,6 +379,8 @@ export function OracleProvider({ children }) {
               success: false,
               fallbackReason,
               errorCode,
+              failureBucket,
+              failureStage,
               errorMessage: discoverErr?.message || "Unknown error",
               budgetSource,
               requestSource,
@@ -257,16 +389,21 @@ export function OracleProvider({ children }) {
           );
         }
       } finally {
-        setIsDiscovering(false);
+        if (isCurrentRequest(requestId)) {
+          setIsDiscovering(false);
+        }
       }
     },
     [
       enrichRecommendationsWithTmdb,
       fetchUserMovieHistory,
+      getResolvedQueryConstraints,
       rejectedTitles,
       selectedMood?.prompt,
       tempPrompt,
       user?.id,
+      beginOracleRequest,
+      isCurrentRequest,
     ]
   );
 
@@ -274,13 +411,13 @@ export function OracleProvider({ children }) {
     if (recommendations.length === 0) return;
     const allNewRejectedTitles = recommendations.map((rec) => rec.title);
     const allNewRejectedIds = tmdbResults.filter(Boolean).map((t) => t.id);
-    setRejectedIds((prev) => [...prev, ...allNewRejectedIds]);
     setRejectedTitles((prev) => [...prev, ...allNewRejectedTitles]);
     await handleDiscover(allNewRejectedIds, allNewRejectedTitles, "reroll_all");
   }, [handleDiscover, recommendations, tmdbResults]);
 
   const handleRerollByTmdbId = useCallback(
     async (tmdbId, fallbackTitle = "", fallbackYear = "") => {
+      const { requestId, signal } = beginOracleRequest();
       const fallbackKey = toKey(fallbackTitle, fallbackYear);
       const targetIndex = tmdbResults.findIndex((movie) => movie?.id === tmdbId);
       const byKeyIndex =
@@ -290,15 +427,13 @@ export function OracleProvider({ children }) {
       if (byKeyIndex < 0) return;
 
       const currentRec = recommendations[byKeyIndex];
-      const currentMovie = tmdbResults[byKeyIndex];
       const rejectedTitle = currentRec?.title || fallbackTitle;
-      const rejectedId = currentMovie?.id || tmdbId || null;
-
       const { allKnownTitles, userTasteContext } = await fetchUserMovieHistory();
       const currentTitles = recommendations.map((rec) => rec.title);
       const excludedTitles = [
         ...new Set([...rejectedTitles, ...allKnownTitles, ...currentTitles, rejectedTitle].filter(Boolean)),
       ];
+      const queryConstraints = await getResolvedQueryConstraints(tempPrompt);
 
       setIsDiscovering(true);
       setError("");
@@ -307,7 +442,10 @@ export function OracleProvider({ children }) {
           userContext: userTasteContext,
           systemPrompt: BASE_SYSTEM_PROMPT,
           rejectedTitles: excludedTitles,
+          queryConstraints,
+          signal,
         });
+        if (!isCurrentRequest(requestId)) return;
         const nextRec = (aiResponse?.recommendations || []).find(
           (candidate) => !excludedTitles.includes(candidate.title)
         );
@@ -317,6 +455,7 @@ export function OracleProvider({ children }) {
 
         const nextMovie = await fetchTMDBMovie(nextRec.title, nextRec.year?.toString() || "");
         const nextProviders = nextMovie?.id ? await fetchWatchProviders(nextMovie.id) : null;
+        if (!isCurrentRequest(requestId)) return;
         const enrichedNextMovie = nextMovie
           ? {
               ...nextMovie,
@@ -330,23 +469,28 @@ export function OracleProvider({ children }) {
           prev.map((providers, idx) => (idx === byKeyIndex ? nextProviders : providers))
         );
         setRejectedTitles((prev) => [...prev, rejectedTitle].filter(Boolean));
-        if (rejectedId) {
-          setRejectedIds((prev) => [...prev, rejectedId]);
-        }
       } catch (rerollErr) {
+        if (isAbortLikeError(rerollErr) || !isCurrentRequest(requestId)) {
+          return;
+        }
         console.error("Oracle targeted reroll failed:", rerollErr);
         setError(getDiscoveryErrorMessage(rerollErr));
       } finally {
-        setIsDiscovering(false);
+        if (isCurrentRequest(requestId)) {
+          setIsDiscovering(false);
+        }
       }
     },
     [
       fetchUserMovieHistory,
+      getResolvedQueryConstraints,
       recommendations,
       rejectedTitles,
       selectedProviderIds,
       tempPrompt,
       tmdbResults,
+      beginOracleRequest,
+      isCurrentRequest,
     ]
   );
 
@@ -379,6 +523,7 @@ export function OracleProvider({ children }) {
       rejectedTitles,
       selectedMood,
       selectedProviderIds,
+      toggleProvider,
       tempPrompt,
       tmdbResults,
     ]

--- a/src/context/OracleContext.jsx
+++ b/src/context/OracleContext.jsx
@@ -11,6 +11,7 @@ import {
   classifyOracleError,
   trackOracleProviderEventSafe,
 } from "../utils/oracleAnalytics";
+import { rankRecommendationsByProviderAffinity } from "../utils/oracleRanking";
 import { isAbortLikeError } from "../utils/oracleReliability";
 import { fetchTMDBMovie, fetchWatchProviders } from "../api/tmdb";
 
@@ -341,9 +342,20 @@ export function OracleProvider({ children }) {
 
         const { mappedTmdb, providerResponses } = await enrichRecommendationsWithTmdb(aiResponse.recommendations);
         if (!isCurrentRequest(requestId)) return;
-        setRecommendations(aiResponse.recommendations);
-        setTmdbResults(mappedTmdb);
-        setProviderResults(providerResponses);
+        const ranked = rankRecommendationsByProviderAffinity({
+          recommendations: aiResponse.recommendations,
+          tmdbResults: mappedTmdb,
+          providerResults: providerResponses,
+          selectedProviderIds,
+        });
+        setRecommendations(ranked.recommendations);
+        setTmdbResults(ranked.tmdbResults);
+        setProviderResults(ranked.providerResults);
+        orchestrationMeta = {
+          ...(orchestrationMeta || {}),
+          rankingMetrics: ranked.rankingMetrics,
+          selectedProviderIds,
+        };
 
         await recordOracleUse(user?.id);
         if (user?.id) {
@@ -356,8 +368,9 @@ export function OracleProvider({ children }) {
               budgetSource,
               requestSource,
               promptType,
-              recommendationCount: aiResponse.recommendations.length,
-              tmdbHitCount: mappedTmdb.filter(Boolean).length,
+              recommendationCount: ranked.recommendations.length,
+              tmdbHitCount: ranked.tmdbResults.filter(Boolean).length,
+              selectedProviderIds,
             })
           );
         }
@@ -375,7 +388,14 @@ export function OracleProvider({ children }) {
           trackOracleProviderEventSafe(
             buildOracleEventPayload({
               userId: user.id,
-              meta: orchestrationMeta || { provider, modelUsed: statusCode ? `status:${statusCode}` : null },
+              meta:
+                orchestrationMeta ||
+                discoverErr?.oracleMeta ||
+                {
+                  provider,
+                  modelUsed: statusCode ? `status:${statusCode}` : null,
+                  selectedProviderIds,
+                },
               success: false,
               fallbackReason,
               errorCode,
@@ -385,6 +405,7 @@ export function OracleProvider({ children }) {
               budgetSource,
               requestSource,
               promptType,
+              selectedProviderIds,
             })
           );
         }
@@ -400,6 +421,7 @@ export function OracleProvider({ children }) {
       getResolvedQueryConstraints,
       rejectedTitles,
       selectedMood?.prompt,
+      selectedProviderIds,
       tempPrompt,
       user?.id,
       beginOracleRequest,
@@ -418,6 +440,7 @@ export function OracleProvider({ children }) {
   const handleRerollByTmdbId = useCallback(
     async (tmdbId, fallbackTitle = "", fallbackYear = "") => {
       const { requestId, signal } = beginOracleRequest();
+      let rerollMeta = null;
       const fallbackKey = toKey(fallbackTitle, fallbackYear);
       const targetIndex = tmdbResults.findIndex((movie) => movie?.id === tmdbId);
       const byKeyIndex =
@@ -446,6 +469,7 @@ export function OracleProvider({ children }) {
           signal,
         });
         if (!isCurrentRequest(requestId)) return;
+        rerollMeta = aiResponse?._meta || null;
         const nextRec = (aiResponse?.recommendations || []).find(
           (candidate) => !excludedTitles.includes(candidate.title)
         );
@@ -469,12 +493,56 @@ export function OracleProvider({ children }) {
           prev.map((providers, idx) => (idx === byKeyIndex ? nextProviders : providers))
         );
         setRejectedTitles((prev) => [...prev, rejectedTitle].filter(Boolean));
+        if (user?.id) {
+          const promptType = selectedMood?.prompt === tempPrompt ? "mood_preset" : "custom_prompt";
+          trackOracleProviderEventSafe(
+            buildOracleEventPayload({
+              userId: user.id,
+              meta: rerollMeta,
+              success: true,
+              budgetSource: "unknown",
+              requestSource: "reroll_single",
+              promptType,
+              recommendationCount: 1,
+              tmdbHitCount: nextMovie ? 1 : 0,
+              selectedProviderIds,
+            })
+          );
+        }
       } catch (rerollErr) {
         if (isAbortLikeError(rerollErr) || !isCurrentRequest(requestId)) {
           return;
         }
         console.error("Oracle targeted reroll failed:", rerollErr);
         setError(getDiscoveryErrorMessage(rerollErr));
+        if (user?.id) {
+          const promptType = selectedMood?.prompt === tempPrompt ? "mood_preset" : "custom_prompt";
+          const { errorCode, fallbackReason, provider, statusCode, failureBucket, failureStage } =
+            classifyOracleError(rerollErr);
+          trackOracleProviderEventSafe(
+            buildOracleEventPayload({
+              userId: user.id,
+              meta:
+                rerollMeta ||
+                rerollErr?.oracleMeta ||
+                {
+                  provider,
+                  modelUsed: statusCode ? `status:${statusCode}` : null,
+                  selectedProviderIds,
+                },
+              success: false,
+              fallbackReason,
+              errorCode,
+              failureBucket,
+              failureStage,
+              errorMessage: rerollErr?.message || "Unknown error",
+              budgetSource: "unknown",
+              requestSource: "reroll_single",
+              promptType,
+              selectedProviderIds,
+            })
+          );
+        }
       } finally {
         if (isCurrentRequest(requestId)) {
           setIsDiscovering(false);
@@ -487,8 +555,10 @@ export function OracleProvider({ children }) {
       recommendations,
       rejectedTitles,
       selectedProviderIds,
+      selectedMood?.prompt,
       tempPrompt,
       tmdbResults,
+      user?.id,
       beginOracleRequest,
       isCurrentRequest,
     ]

--- a/src/index.css
+++ b/src/index.css
@@ -80,9 +80,6 @@
     transform: translateY(-1px);
   }
 
-  .font-creepster {
-    font-family: "Creepster", cursive;
-  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/pages/DiscoveryPage.jsx
+++ b/src/pages/DiscoveryPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useUser } from "../context/UserContext";
 import { useLists } from "../context/ListContext";
 import { useToast } from "../context/ToastContext";
@@ -74,6 +74,12 @@ function DiscoveryContent() {
   const [isLogModalOpen, setIsLogModalOpen] = useState(false);
   const [selectedMovieForModal, setSelectedMovieForModal] = useState(null);
   const [isOnline, setIsOnline] = useState(navigator.onLine);
+  const watchlistInFlightRef = useRef(new Set());
+  const watchlistKnownIdsRef = useRef(new Set());
+  const discoverRequestStartRef = useRef(null);
+  const rerollOneRequestStartRef = useRef(null);
+  const perfDebugEnabled =
+    String(import.meta.env.VITE_FEATURE_ORACLE_PERF_DEBUG || "").toLowerCase() === "true";
 
   useEffect(() => {
     const handleOnline = () => setIsOnline(true);
@@ -86,30 +92,31 @@ function DiscoveryContent() {
     };
   }, []);
 
-  const handleMoodSelect = (mood) => {
+  const handleMoodSelect = useCallback((mood) => {
     setSelectedMood(mood);
     setTempPrompt(mood.prompt);
-  };
+  }, [setSelectedMood, setTempPrompt]);
 
-  const handleChange = (e) => {
+  const handleChange = useCallback((e) => {
     setTempPrompt(e.target.value);
-  };
+  }, [setTempPrompt]);
 
-  const handleSubmit = (e) => {
+  const handleSubmit = useCallback((e) => {
     e.preventDefault();
     if (tempPrompt.trim()) {
+      discoverRequestStartRef.current = performance.now();
       handleDiscover();
     }
-  };
+  }, [handleDiscover, tempPrompt]);
 
-  const handleKeyDown = (e) => {
+  const handleKeyDown = useCallback((e) => {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       handleSubmit(e);
     }
-  };
+  }, [handleSubmit]);
 
-  const getMovieDataForModal = (movie) => {
+  const getMovieDataForModal = useCallback((movie) => {
     if (!movie) return null;
     return {
       id: movie.id,
@@ -118,7 +125,89 @@ function DiscoveryContent() {
       release_date: movie.release_date,
       overview: movie.overview,
     };
-  };
+  }, []);
+
+  const selectedProviderNamesText = useMemo(() => {
+    if (!selectedProviderIds.length) return "";
+    return TOP_STREAMING_PROVIDERS_US.filter((p) => selectedProviderIds.includes(p.id))
+      .map((p) => p.name)
+      .join(" · ");
+  }, [selectedProviderIds]);
+
+  const handleOpenWatchedModal = useCallback((movie) => {
+    setSelectedMovieForModal(movie);
+    setIsLogModalOpen(true);
+  }, []);
+
+  const handleAddToWatchlist = useCallback(
+    async (movie) => {
+      if (!movie || !user?.id || !movie.id) return;
+      if (watchlistInFlightRef.current.has(movie.id)) return;
+      if (watchlistKnownIdsRef.current.has(movie.id)) {
+        toast.info("Already in Watchlist");
+        return;
+      }
+
+      watchlistInFlightRef.current.add(movie.id);
+      try {
+        const supabase = getSupabase();
+        const { data: existing } = await supabase
+          .from("movie_logs")
+          .select("id")
+          .eq("user_id", user.id)
+          .eq("tmdb_id", movie.id)
+          .eq("watch_status", "to-watch")
+          .maybeSingle();
+        if (existing) {
+          watchlistKnownIdsRef.current.add(movie.id);
+          toast.info("Already in Watchlist");
+          return;
+        }
+        const { error: insertError } = await supabase.from("movie_logs").insert({
+          user_id: user.id,
+          tmdb_id: movie.id,
+          title: movie.title,
+          poster_path: movie.poster_path,
+          watch_status: "to-watch",
+        });
+        if (insertError) throw insertError;
+        watchlistKnownIdsRef.current.add(movie.id);
+        toast.success("Added to Watchlist");
+      } catch (watchErr) {
+        console.error("Watchlist error:", watchErr);
+        toast.error("Failed to add to watchlist");
+      } finally {
+        watchlistInFlightRef.current.delete(movie.id);
+      }
+    },
+    [toast, user?.id]
+  );
+
+  const handleRerollOne = useCallback(
+    (tmdbId, title, year) => {
+      rerollOneRequestStartRef.current = performance.now();
+      onRerollByTmdbId(tmdbId, title, year);
+    },
+    [onRerollByTmdbId]
+  );
+
+  useEffect(() => {
+    if (!perfDebugEnabled) return;
+    if (!isDiscovering && recommendations.length > 0 && discoverRequestStartRef.current) {
+      const durationMs = Math.round(performance.now() - discoverRequestStartRef.current);
+      console.log(`[OraclePerf] discover->firstCards ${durationMs}ms (${recommendations.length} cards)`);
+      discoverRequestStartRef.current = null;
+    }
+  }, [isDiscovering, perfDebugEnabled, recommendations.length]);
+
+  useEffect(() => {
+    if (!perfDebugEnabled) return;
+    if (!isDiscovering && rerollOneRequestStartRef.current) {
+      const durationMs = Math.round(performance.now() - rerollOneRequestStartRef.current);
+      console.log(`[OraclePerf] rerollOne ${durationMs}ms`);
+      rerollOneRequestStartRef.current = null;
+    }
+  }, [isDiscovering, perfDebugEnabled]);
 
   return (
     <div className="discovery-page">
@@ -178,12 +267,7 @@ function DiscoveryContent() {
           </div>
           {selectedProviderIds.length > 0 && (
             <p className="provider-filtering-note">
-              Filtering toward:{" "}
-              {TOP_STREAMING_PROVIDERS_US.filter((p) =>
-                selectedProviderIds.includes(p.id),
-              )
-                .map((p) => p.name)
-                .join(" · ")}
+              Filtering toward: {selectedProviderNamesText}
             </p>
           )}
           <label className="prompt-label">Or describe your vibe:</label>
@@ -240,40 +324,9 @@ function DiscoveryContent() {
                   isMovieInList={isMovieInList}
                   addMovieToList={addMovieToList}
                   toast={toast}
-                  onOpenWatchedModal={(movie) => {
-                    setSelectedMovieForModal(movie);
-                    setIsLogModalOpen(true);
-                  }}
-                  onAddToWatchlist={async (movie) => {
-                    if (!movie || !user?.id) return;
-                    try {
-                      const supabase = getSupabase();
-                      const { data: existing } = await supabase
-                        .from("movie_logs")
-                        .select("id")
-                        .eq("user_id", user.id)
-                        .eq("tmdb_id", movie.id)
-                        .eq("watch_status", "to-watch")
-                        .maybeSingle();
-                      if (existing) {
-                        toast.info("Already in Watchlist");
-                        return;
-                      }
-                      const { error: insertError } = await supabase.from("movie_logs").insert({
-                        user_id: user.id,
-                        tmdb_id: movie.id,
-                        title: movie.title,
-                        poster_path: movie.poster_path,
-                        watch_status: "to-watch",
-                      });
-                      if (insertError) throw insertError;
-                      toast.success("Added to Watchlist");
-                    } catch (watchErr) {
-                      console.error("Watchlist error:", watchErr);
-                      toast.error("Failed to add to watchlist");
-                    }
-                  }}
-                  onRerollOne={handleRerollByTmdbId}
+                  onOpenWatchedModal={handleOpenWatchedModal}
+                  onAddToWatchlist={handleAddToWatchlist}
+                  onRerollOne={handleRerollOne}
                   onRerollAll={handleRerollAll}
                 />
               );

--- a/src/pages/DiscoveryPage.jsx
+++ b/src/pages/DiscoveryPage.jsx
@@ -62,7 +62,6 @@ function DiscoveryContent() {
     recommendations,
     tmdbResults,
     error,
-    rejectedTitles,
     selectedProviderIds,
     toggleProvider,
     handleDiscover,
@@ -186,9 +185,9 @@ function DiscoveryContent() {
   const handleRerollOne = useCallback(
     (tmdbId, title, year) => {
       rerollOneRequestStartRef.current = performance.now();
-      onRerollByTmdbId(tmdbId, title, year);
+      handleRerollByTmdbId(tmdbId, title, year);
     },
-    [onRerollByTmdbId]
+    [handleRerollByTmdbId]
   );
 
   useEffect(() => {

--- a/src/pages/LibraryPage.jsx
+++ b/src/pages/LibraryPage.jsx
@@ -11,7 +11,14 @@ import ArchiveImporterModal from '../components/ArchiveImporterModal';
 import { MovieGridSkeleton } from '../components/Skeleton';
 import { runPosterMigration } from '../utils/posterMigration';
 import { parseLibraryQuery } from '../utils/naturalLanguageSort';
+import {
+  movieMatchesGenreFilter,
+  movieMatchesMoodFilter,
+  movieMatchesRatingFilter,
+  normalizeNlMoodToken,
+} from '../utils/libraryAdvancedSearch';
 import { buildListSharePayload, buildMovieSharePayload, executeShare } from '../utils/share';
+import LibraryAdvancedFilters from '../components/LibraryAdvancedFilters';
 import SeoHead from '../components/seo/SeoHead';
 import './LibraryPage.css';
 
@@ -58,6 +65,11 @@ function LibraryPage() {
   const [collabActionLoading, setCollabActionLoading] = useState('');
   const [parsedQuery, setParsedQuery] = useState(parseLibraryQuery(''));
   const [isOnline, setIsOnline] = useState(navigator.onLine);
+  const [advancedMoods, setAdvancedMoods] = useState([]);
+  const [moodMatchMode, setMoodMatchMode] = useState('any');
+  const [advancedGenres, setAdvancedGenres] = useState([]);
+  const [minRating, setMinRating] = useState('');
+  const [maxRating, setMaxRating] = useState('');
 
   useEffect(() => {
     const handleOnline = () => setIsOnline(true);
@@ -326,10 +338,25 @@ function LibraryPage() {
   const filteredMovies = movies.filter((movie) => {
     const normalizedSearch = (parsedQuery.searchText || searchQuery).toLowerCase();
     const matchesSearch = movie.title.toLowerCase().includes(normalizedSearch);
-    const matchesMood = !selectedMood || (movie.moods && movie.moods.includes(selectedMood));
+
+    let moodIdsForFilter = [];
+    let moodMode = moodMatchMode;
+    if (advancedMoods.length > 0) {
+      moodIdsForFilter = advancedMoods;
+    } else {
+      const single =
+        selectedMood || normalizeNlMoodToken(parsedQuery.mood || '');
+      moodIdsForFilter = single ? [single] : [];
+      moodMode = 'any';
+    }
+    const matchesMood = movieMatchesMoodFilter(movie, moodIdsForFilter, moodMode);
+
+    const matchesGenre = movieMatchesGenreFilter(movie, advancedGenres);
+    const matchesRating = movieMatchesRatingFilter(movie, minRating, maxRating);
+
     const runtimeValue = Number(movie.runtime_minutes || movie.runtime || 0);
     const matchesRuntime = !parsedQuery.maxRuntime || !runtimeValue || runtimeValue <= parsedQuery.maxRuntime;
-    return matchesSearch && matchesMood && matchesRuntime;
+    return matchesSearch && matchesMood && matchesGenre && matchesRating && matchesRuntime;
   });
 
   const sortedMovies = [...filteredMovies].sort((a, b) => {
@@ -343,7 +370,28 @@ function LibraryPage() {
     }
   });
 
-  const allMoods = [...new Set(movies.flatMap((m) => m.moods || []))];
+  const allGenresInShelf = [
+    ...new Set(
+      movies.flatMap((m) =>
+        Array.isArray(m.genres) ? m.genres.filter(Boolean) : [],
+      ),
+    ),
+  ].sort((a, b) => a.localeCompare(b));
+
+  const handleToggleGenre = (genre) => {
+    setAdvancedGenres((prev) =>
+      prev.includes(genre) ? prev.filter((g) => g !== genre) : [...prev, genre],
+    );
+  };
+
+  const handleClearAdvancedFilters = () => {
+    setAdvancedMoods([]);
+    setAdvancedGenres([]);
+    setMinRating('');
+    setMaxRating('');
+    setMoodMatchMode('any');
+    setSelectedMood('');
+  };
 
   const shelfCountLabel =
     activeTab === 'lists'
@@ -728,24 +776,6 @@ function LibraryPage() {
                   />
                   <p className="library-filter-hint">Natural language updates mood, sort, and filters when it recognizes them.</p>
                 </div>
-                {allMoods.length > 0 && (
-                  <div className="library-filter-field">
-                    <label htmlFor="library-mood" className="library-filter-label">Mood</label>
-                    <select
-                      id="library-mood"
-                      value={selectedMood}
-                      onChange={(e) => setSelectedMood(e.target.value)}
-                      className="library-select"
-                    >
-                      <option value="">All moods</option>
-                      {allMoods.map((mood) => (
-                        <option key={mood} value={mood}>
-                          {mood.charAt(0).toUpperCase() + mood.slice(1)}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                )}
                 <div className="library-filter-field">
                   <label htmlFor="library-sort" className="library-filter-label">Sort</label>
                   <select
@@ -761,6 +791,20 @@ function LibraryPage() {
                     ))}
                   </select>
                 </div>
+                <LibraryAdvancedFilters
+                  selectedMoods={advancedMoods}
+                  onMoodsChange={setAdvancedMoods}
+                  moodMatchMode={moodMatchMode}
+                  onMoodMatchModeChange={setMoodMatchMode}
+                  genreOptions={allGenresInShelf}
+                  selectedGenres={advancedGenres}
+                  onToggleGenre={handleToggleGenre}
+                  minRating={minRating}
+                  maxRating={maxRating}
+                  onMinRatingChange={setMinRating}
+                  onMaxRatingChange={setMaxRating}
+                  onClearAdvanced={handleClearAdvancedFilters}
+                />
               </div>
             </section>
 
@@ -814,6 +858,7 @@ function LibraryPage() {
           onSaved={(updated) => {
             setMovies(movies.map((m) => (m.id === updated.id ? updated : m)));
             setShowEditModal(false);
+            toast.success(`"${updated?.title || editingMovie?.title || 'Movie'}" logged successfully!`);
           }}
         />
       )}
@@ -842,9 +887,9 @@ function LibraryPage() {
         <LogMovieModal
           movie={null}
           onClose={() => setShowScanModal(false)}
-          onSaved={() => {
+          onSaved={(saved) => {
             setShowScanModal(false);
-            toast.success('Scanned movie added to your library.');
+            toast.success(`"${saved?.title || 'Movie'}" logged successfully!`);
             fetchMovies();
           }}
         />

--- a/src/pages/MatchmakerPage.css
+++ b/src/pages/MatchmakerPage.css
@@ -17,13 +17,13 @@
 }
 
 .matchmaker-title {
-  font-family: 'Creepster', cursive;
-  font-size: 48px;
-  font-weight: 700;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  font-size: clamp(2rem, 5vw, 2.75rem);
+  font-weight: 800;
   color: #f97316;
   margin: 0 0 12px 0;
-  text-shadow: 0 0 20px rgba(249, 115, 22, 0.3);
-  letter-spacing: 2px;
+  text-shadow: 0 0 20px rgba(249, 115, 22, 0.25);
+  letter-spacing: -0.03em;
 }
 
 .matchmaker-subtitle {

--- a/src/pages/MatchmakerPage.jsx
+++ b/src/pages/MatchmakerPage.jsx
@@ -256,7 +256,7 @@ function MatchmakerPage() {
       <div className="matchmaker-container">
         {/* Header */}
         <div className="matchmaker-header">
-          <h1 className="matchmaker-title font-creepster">The Matchmaker</h1>
+          <h1 className="matchmaker-title">The Matchmaker</h1>
           <p className="matchmaker-subtitle">
             Find your movie soulmate. Compare tastes, discover conflicts, and see your Synergy Score.
           </p>

--- a/src/pages/MovieDetail.css
+++ b/src/pages/MovieDetail.css
@@ -41,6 +41,34 @@
   margin: 0;
 }
 
+.movie-not-found-state {
+  min-height: 60vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 2rem 1rem;
+  background: #0a0a0a;
+}
+
+.movie-not-found-title {
+  font-size: clamp(1.75rem, 4vw, 2.25rem);
+  font-weight: 800;
+  color: #f97316;
+  margin: 0 0 1rem;
+  letter-spacing: -0.03em;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+}
+
+.movie-not-found-copy {
+  font-size: 1rem;
+  color: #a1a1aa;
+  margin: 0 0 2rem;
+  max-width: 28rem;
+  line-height: 1.55;
+}
+
 .back-button {
   padding: 12px 24px;
   font-size: 14px;

--- a/src/pages/MovieDetail.jsx
+++ b/src/pages/MovieDetail.jsx
@@ -323,6 +323,8 @@ function MovieDetail() {
     setUserLog(savedLog);
     setEditingLog(null);
     setShowLogModal(false);
+    const loggedTitle = savedLog?.title || movie?.title || "Movie";
+    toast.success(`"${loggedTitle}" logged successfully!`);
   };
 
   const handleToggleWatchlist = async () => {
@@ -427,20 +429,18 @@ function MovieDetail() {
   // Ghost Hunter Fix - catches invalid IDs, empty data, or TMDB returning 200 OK with no data
   if (!movie || !movie.title) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-[60vh] text-center px-4">
+      <div className="movie-not-found-state">
         <SeoHead
           title="Movie Not Found"
           description="The requested movie could not be found in Filmgraph's archive."
           pathname={`/movie/${id}`}
         />
-        <h2 className="text-4xl font-creepster text-accent mb-4">
-          Signal Lost
-        </h2>
-        <p className="text-text-muted mb-8 max-w-md">
+        <h2 className="movie-not-found-title">Signal Lost</h2>
+        <p className="movie-not-found-copy">
           The archives have no record of this tape. It may have been corrupted,
           deleted, or it never existed at all.
         </p>
-        <button onClick={handleBack} className="btn-primary">
+        <button type="button" onClick={handleBack} className="btn-primary">
           Return to Library
         </button>
       </div>

--- a/src/pages/ProfilePage.css
+++ b/src/pages/ProfilePage.css
@@ -248,6 +248,19 @@
   text-decoration: none;
 }
 
+.streaming-preferences-hint {
+  margin: -8px 0 16px;
+  font-size: 14px;
+  line-height: 1.55;
+  color: #a1a1aa;
+}
+
+.streaming-preferences-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
 /* Social Hub Section */
 .social-hub-section {
   margin-bottom: 24px;
@@ -602,6 +615,34 @@
   .secondary-stats-grid {
     grid-template-columns: 1fr 1fr;
   }
+}
+
+.profile-year-recap {
+  margin-bottom: 28px;
+  padding: 18px 20px;
+  background: #121212;
+  border-radius: 12px;
+  border: 1px solid rgba(251, 146, 60, 0.22);
+}
+
+.profile-year-recap-link {
+  display: inline-block;
+  font-weight: 700;
+  font-size: 1rem;
+  color: #fb923c;
+  text-decoration: none;
+}
+
+.profile-year-recap-link:hover {
+  color: #fdba74;
+  text-decoration: underline;
+}
+
+.profile-year-recap-hint {
+  margin: 8px 0 0;
+  font-size: 0.875rem;
+  color: #888888;
+  line-height: 1.45;
 }
 
 /* Search Bar Wrapper - Ensure visibility */

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -552,15 +552,13 @@ function ProfilePage() {
           )}
         </div>
 
-        {/* Social Hub Section */}
+        {/* Streaming preferences */}
         <div className="social-hub-section">
-          <div className="social-hub-header">
-            <h2 className="social-hub-title font-creepster">Streaming Preferences</h2>
-          </div>
-          <p className="profile-email" style={{ marginBottom: "10px" }}>
+          <h2 className="insights-title">Streaming Preferences</h2>
+          <p className="streaming-preferences-hint">
             Pick services you currently have. Oracle uses this to guide recommendations.
           </p>
-          <div style={{ display: "flex", flexWrap: "wrap", gap: "8px" }}>
+          <div className="streaming-preferences-chips">
             {TOP_STREAMING_PROVIDERS_US.map((provider) => {
               const active = userProviders.includes(provider.id);
               return (
@@ -585,7 +583,7 @@ function ProfilePage() {
         {/* Social Hub Section */}
         <div className="social-hub-section">
           <div className="social-hub-header">
-            <h2 className="social-hub-title font-creepster">
+            <h2 className="social-hub-title">
               <svg
                 className="social-hub-icon"
                 viewBox="0 0 24 24"
@@ -735,6 +733,16 @@ function ProfilePage() {
             </span>
             <span className="stat-label">Physical Owned</span>
           </div>
+        </div>
+
+        <div className="profile-year-recap">
+          <Link to="/year-in-review" className="profile-year-recap-link">
+            Year in Review
+          </Link>
+          <p className="profile-year-recap-hint">
+            Wrapped-style recap for any calendar year — ratings, genres, moods,
+            and more.
+          </p>
         </div>
 
         {/* Movie Insights */}

--- a/src/pages/TrendingMovies.css
+++ b/src/pages/TrendingMovies.css
@@ -94,7 +94,7 @@
 .backdrop-card {
   cursor: pointer;
   border-radius: 8px;
-  overflow: hidden;
+  overflow: visible;
   transition: transform 0.2s ease;
 }
 
@@ -106,10 +106,18 @@
   position: relative;
   padding-top: 56.25%;
   background: #1a1a1a;
-  overflow: hidden;
+  overflow: visible;
 }
 
-.backdrop-image-wrapper img {
+/* Clip only the media so list dropdowns / quick actions are not cut off */
+.backdrop-media-clip {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  border-radius: 8px;
+}
+
+.backdrop-media-clip img {
   position: absolute;
   top: 0;
   left: 0;
@@ -119,11 +127,11 @@
   transition: transform 0.3s ease;
 }
 
-.backdrop-card:hover .backdrop-image-wrapper img {
+.backdrop-card:hover .backdrop-media-clip img {
   transform: scale(1.05);
 }
 
-.no-backdrop {
+.backdrop-media-clip .no-backdrop {
   position: absolute;
   top: 0;
   left: 0;

--- a/src/pages/TrendingMovies.jsx
+++ b/src/pages/TrendingMovies.jsx
@@ -193,21 +193,23 @@ function TrendingMovies() {
               onClick={() => handleMovieClick(movie)}
             >
               <div className="backdrop-image-wrapper">
-                {movie.backdrop_path ? (
-                  <img
-                    src={getBackdropUrl(movie.backdrop_path, 'w780')}
-                    alt={movie.title}
-                    loading="lazy"
-                  />
-                ) : (
-                  <div className="no-backdrop">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1">
-                      <rect x="3" y="3" width="18" height="18" rx="2" />
-                      <circle cx="8.5" cy="8.5" r="1.5" />
-                      <path d="M21 15l-5-5L5 21" />
-                    </svg>
-                  </div>
-                )}
+                <div className="backdrop-media-clip">
+                  {movie.backdrop_path ? (
+                    <img
+                      src={getBackdropUrl(movie.backdrop_path, 'w780')}
+                      alt={movie.title}
+                      loading="lazy"
+                    />
+                  ) : (
+                    <div className="no-backdrop">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1">
+                        <rect x="3" y="3" width="18" height="18" rx="2" />
+                        <circle cx="8.5" cy="8.5" r="1.5" />
+                        <path d="M21 15l-5-5L5 21" />
+                      </svg>
+                    </div>
+                  )}
+                </div>
                 <div className="backdrop-overlay"></div>
                 <div
                   className="backdrop-quick-actions"

--- a/src/pages/YearInReviewPage.css
+++ b/src/pages/YearInReviewPage.css
@@ -1,0 +1,249 @@
+.year-in-review-page {
+  min-height: 100vh;
+  background: linear-gradient(180deg, #09090b 0%, #18181b 40%, #09090b 100%);
+  color: #fafafa;
+  padding-bottom: 3rem;
+}
+
+.yir-container {
+  max-width: 52rem;
+  margin: 0 auto;
+  padding: 1.5rem 1.25rem 2rem;
+}
+
+.yir-header {
+  margin-bottom: 2rem;
+}
+
+.yir-back {
+  display: inline-block;
+  font-size: 0.875rem;
+  color: #a1a1aa;
+  text-decoration: none;
+  margin-bottom: 1rem;
+}
+
+.yir-back:hover {
+  color: #fb923c;
+}
+
+.yir-title {
+  font-size: clamp(1.75rem, 4vw, 2.25rem);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  margin: 0 0 0.35rem;
+}
+
+.yir-subtitle {
+  margin: 0 0 1.25rem;
+  color: #a1a1aa;
+  font-size: 0.95rem;
+}
+
+.yir-year-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.yir-year-label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #71717a;
+}
+
+.yir-year-select {
+  background: #18181b;
+  border: 1px solid rgba(251, 146, 60, 0.35);
+  color: #fafafa;
+  border-radius: 0.5rem;
+  padding: 0.45rem 2rem 0.45rem 0.65rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.yir-year-select:focus {
+  outline: 2px solid #ea580c;
+  outline-offset: 2px;
+}
+
+.yir-alert {
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+}
+
+.yir-alert--error {
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.35);
+  color: #fecaca;
+}
+
+.yir-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 3rem 1rem;
+  color: #a1a1aa;
+}
+
+.yir-spinner {
+  width: 2.5rem;
+  height: 2.5rem;
+  border: 3px solid #27272a;
+  border-top-color: #f97316;
+  border-radius: 50%;
+  animation: yir-spin 0.8s linear infinite;
+}
+
+@keyframes yir-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.yir-empty {
+  text-align: center;
+  padding: 2.5rem 1rem;
+  background: rgba(24, 24, 27, 0.85);
+  border: 1px solid rgba(63, 63, 70, 0.6);
+  border-radius: 1rem;
+}
+
+.yir-empty-title {
+  margin: 0 0 0.75rem;
+  font-size: 1.35rem;
+}
+
+.yir-empty-copy {
+  margin: 0 0 1.25rem;
+  color: #a1a1aa;
+  line-height: 1.55;
+  max-width: 28rem;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.yir-empty-cta {
+  display: inline-block;
+  background: linear-gradient(135deg, #ea580c, #f97316);
+  color: #0a0a0a;
+  font-weight: 700;
+  padding: 0.65rem 1.25rem;
+  border-radius: 0.5rem;
+  text-decoration: none;
+}
+
+.yir-empty-cta:hover {
+  filter: brightness(1.08);
+}
+
+.yir-hero {
+  display: grid;
+  gap: 1.25rem;
+  padding: 1.75rem;
+  margin-bottom: 2rem;
+  background: linear-gradient(
+    145deg,
+    rgba(234, 88, 12, 0.18) 0%,
+    rgba(24, 24, 27, 0.95) 45%,
+    rgba(9, 9, 11, 0.98) 100%
+  );
+  border: 1px solid rgba(251, 146, 60, 0.25);
+  border-radius: 1rem;
+}
+
+.yir-hero-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.yir-hero-number {
+  font-size: clamp(2.75rem, 8vw, 4rem);
+  font-weight: 800;
+  line-height: 1;
+  background: linear-gradient(180deg, #fff 30%, #fdba74 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.yir-hero-label {
+  font-size: 1rem;
+  color: #d4d4d8;
+  font-weight: 500;
+}
+
+.yir-hero-meta {
+  font-size: 0.95rem;
+  color: #d4d4d8;
+  line-height: 1.65;
+}
+
+.yir-hero-meta p {
+  margin: 0.35rem 0;
+}
+
+.yir-hero-meta strong {
+  color: #fafafa;
+  font-weight: 600;
+}
+
+.yir-meta-note {
+  color: #71717a;
+  font-weight: 400;
+  font-size: 0.85rem;
+}
+
+.yir-section {
+  margin-bottom: 2.25rem;
+}
+
+.yir-section-title {
+  font-size: 1.15rem;
+  font-weight: 700;
+  margin: 0 0 1rem;
+  color: #e4e4e7;
+}
+
+.yir-chart-wrap {
+  background: rgba(24, 24, 27, 0.65);
+  border: 1px solid rgba(63, 63, 70, 0.5);
+  border-radius: 0.75rem;
+  padding: 1rem 0.5rem;
+}
+
+.yir-chart-wrap--pie {
+  padding-bottom: 0.25rem;
+}
+
+.yir-footer {
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid rgba(63, 63, 70, 0.45);
+}
+
+.yir-disclaimer {
+  margin: 0;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  color: #71717a;
+  max-width: 36rem;
+}
+
+.yir-disclaimer--muted {
+  margin-top: 1.5rem;
+}
+
+@media (min-width: 640px) {
+  .yir-hero {
+    grid-template-columns: 1fr 1fr;
+    align-items: center;
+  }
+}

--- a/src/pages/YearInReviewPage.jsx
+++ b/src/pages/YearInReviewPage.jsx
@@ -1,0 +1,438 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  PieChart,
+  Pie,
+  Cell,
+  Legend,
+} from "recharts";
+import { useUser } from "../context/UserContext";
+import { getSupabase } from "../supabaseClient";
+import { buildYearInReview } from "../utils/yearInReview";
+import SeoHead from "../components/seo/SeoHead";
+import "./YearInReviewPage.css";
+
+const GENRE_COLORS = [
+  "#f97316",
+  "#ea580c",
+  "#c2410c",
+  "#9a3412",
+  "#fdba74",
+  "#fb923c",
+  "#eab308",
+  "#ca8a04",
+];
+
+const MOOD_COLORS = {
+  emotional: "#f87171",
+  vibe: "#c084fc",
+  intellectual: "#94a3b8",
+};
+
+const MOOD_CATEGORIES = {
+  bittersweet: "emotional",
+  heartwarming: "emotional",
+  tearjerker: "emotional",
+  uplifting: "emotional",
+  bleak: "emotional",
+  atmospheric: "vibe",
+  dark: "vibe",
+  gritty: "vibe",
+  neon: "vibe",
+  tense: "vibe",
+  whimsical: "vibe",
+  gory: "vibe",
+  eerie: "vibe",
+  claustrophobic: "vibe",
+  campy: "vibe",
+  dread: "vibe",
+  "jump-scary": "vibe",
+  psychological: "intellectual",
+  mindbending: "intellectual",
+  challenging: "intellectual",
+  philosophical: "intellectual",
+  slowburn: "intellectual",
+  complex: "intellectual",
+};
+
+function formatMoodLabel(id) {
+  if (!id) return "";
+  const s = String(id);
+  return s.charAt(0).toUpperCase() + s.slice(1).replace(/-/g, " ");
+}
+
+function moodBarColor(moodId) {
+  const cat = MOOD_CATEGORIES[moodId] || "vibe";
+  return MOOD_COLORS[cat] || MOOD_COLORS.vibe;
+}
+
+const CURRENT_YEAR = new Date().getFullYear();
+const MIN_YEAR = 2015;
+
+function parseYearParam(raw) {
+  if (raw == null || raw === "") return CURRENT_YEAR;
+  const y = Number.parseInt(String(raw), 10);
+  if (!Number.isFinite(y)) return null;
+  if (y < MIN_YEAR || y > CURRENT_YEAR) return null;
+  return y;
+}
+
+function YearInReviewPage() {
+  const { year: yearParam } = useParams();
+  const navigate = useNavigate();
+  const { user, isAuthenticated } = useUser();
+  const [logs, setLogs] = useState([]);
+  const [loadError, setLoadError] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
+
+  const selectedYear = useMemo(() => parseYearParam(yearParam), [yearParam]);
+
+  useEffect(() => {
+    if (yearParam != null && yearParam !== "" && selectedYear === null) {
+      navigate("/year-in-review", { replace: true });
+    }
+  }, [yearParam, selectedYear, navigate]);
+
+  const effectiveYear = selectedYear ?? CURRENT_YEAR;
+
+  const fetchLogs = useCallback(async () => {
+    if (!user?.id) return;
+    setIsLoading(true);
+    setLoadError("");
+    try {
+      const supabase = getSupabase();
+      // Omit watched_at until DB migration adds column (see supabase/migrations/*movie_logs_watched_at.sql).
+      const { data, error } = await supabase
+        .from("movie_logs")
+        .select(
+          "watch_status, rating, genres, moods, review, created_at, source_upc",
+        )
+        .eq("user_id", user.id);
+
+      if (error) throw error;
+      setLogs(data || []);
+    } catch (e) {
+      console.error("YearInReview fetch:", e);
+      setLoadError(e?.message || "Could not load your logs.");
+      setLogs([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [user?.id]);
+
+  useEffect(() => {
+    if (isAuthenticated && user?.id) {
+      fetchLogs();
+    }
+  }, [isAuthenticated, user?.id, fetchLogs]);
+
+  const recap = useMemo(
+    () => buildYearInReview(effectiveYear, logs),
+    [effectiveYear, logs],
+  );
+
+  const genrePieData = useMemo(
+    () =>
+      recap.topGenres.map((g, index) => ({
+        name: g.name,
+        value: g.count,
+        color: GENRE_COLORS[index % GENRE_COLORS.length],
+      })),
+    [recap.topGenres],
+  );
+
+  const moodBarData = useMemo(
+    () =>
+      recap.topMoods.map((m) => ({
+        name: formatMoodLabel(m.name),
+        count: m.count,
+        moodId: m.name,
+      })),
+    [recap.topMoods],
+  );
+
+  const yearOptions = useMemo(() => {
+    const list = [];
+    for (let y = CURRENT_YEAR; y >= MIN_YEAR; y--) list.push(y);
+    return list;
+  }, []);
+
+  if (!isAuthenticated) return null;
+
+  const pathname =
+    effectiveYear === CURRENT_YEAR && (yearParam == null || yearParam === "")
+      ? "/year-in-review"
+      : `/year-in-review/${effectiveYear}`;
+
+  return (
+    <div className="year-in-review-page">
+      <SeoHead
+        title={`Year in Review ${effectiveYear}`}
+        description={`Your Filmgraph recap for ${effectiveYear}: films watched, ratings, genres, moods, and more.`}
+        pathname={pathname}
+      />
+
+      <div className="yir-container">
+        <header className="yir-header">
+          <Link to="/profile" className="yir-back">
+            ← Profile
+          </Link>
+          <h1 className="yir-title">Year in Review</h1>
+          <p className="yir-subtitle">
+            Your film year — wrapped in orange (well, amber).
+          </p>
+
+          <div className="yir-year-row">
+            <label htmlFor="yir-year-select" className="yir-year-label">
+              Year
+            </label>
+            <select
+              id="yir-year-select"
+              className="yir-year-select"
+              value={effectiveYear}
+              onChange={(e) => {
+                const y = Number(e.target.value);
+                if (y === CURRENT_YEAR) navigate("/year-in-review");
+                else navigate(`/year-in-review/${y}`);
+              }}
+            >
+              {yearOptions.map((y) => (
+                <option key={y} value={y}>
+                  {y}
+                </option>
+              ))}
+            </select>
+          </div>
+        </header>
+
+        {loadError && (
+          <div className="yir-alert yir-alert--error" role="alert">
+            {loadError}
+          </div>
+        )}
+
+        {isLoading ? (
+          <div className="yir-loading">
+            <div className="yir-spinner" aria-hidden />
+            <p>Pulling your year…</p>
+          </div>
+        ) : recap.filmCount === 0 ? (
+          <div className="yir-empty">
+            <h2 className="yir-empty-title">No watched films in {effectiveYear}</h2>
+            <p className="yir-empty-copy">
+              Logs marked watched with a date in {effectiveYear} show up here.
+              Start logging or move back a year if your history lives in another
+              calendar year.
+            </p>
+            <Link to="/library" className="yir-empty-cta">
+              Go to Library
+            </Link>
+            <p className="yir-disclaimer yir-disclaimer--muted">
+              Based on log dates ({effectiveYear}). Manual watch-date editing
+              coming soon.
+            </p>
+          </div>
+        ) : (
+          <>
+            <section className="yir-hero">
+              <div className="yir-hero-stat">
+                <span className="yir-hero-number">{recap.filmCount}</span>
+                <span className="yir-hero-label">
+                  films watched in {effectiveYear}
+                </span>
+              </div>
+              <div className="yir-hero-meta">
+                {recap.avgRating != null ? (
+                  <p>
+                    <strong>Average rating:</strong> {recap.avgRating} / 5
+                    <span className="yir-meta-note">
+                      {" "}
+                      ({recap.ratedFilmCount} rated)
+                    </span>
+                  </p>
+                ) : (
+                  <p>
+                    <strong>Average rating:</strong> — (add ratings to your logs
+                    for this stat)
+                  </p>
+                )}
+                <p>
+                  <strong>Reviews written:</strong> {recap.reviewsWrittenCount}
+                </p>
+                <p>
+                  <strong>From your shelf (UPC):</strong>{" "}
+                  {recap.physicalScanCount}
+                </p>
+              </div>
+            </section>
+
+            <section className="yir-section">
+              <h2 className="yir-section-title">Films per month</h2>
+              <div className="yir-chart-wrap">
+                <ResponsiveContainer width="100%" height={260}>
+                  <BarChart data={recap.monthlyCounts}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#2a2a2a" />
+                    <XAxis dataKey="label" stroke="#888888" fontSize={11} />
+                    <YAxis
+                      stroke="#888888"
+                      fontSize={11}
+                      allowDecimals={false}
+                    />
+                    <Tooltip
+                      contentStyle={{
+                        backgroundColor: "#1a1a1a",
+                        border: "1px solid #2a2a2a",
+                        borderRadius: "8px",
+                        color: "#ffffff",
+                      }}
+                    />
+                    <Bar
+                      dataKey="count"
+                      fill="#f97316"
+                      radius={[4, 4, 0, 0]}
+                      name="Films"
+                    />
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            </section>
+
+            {recap.ratingHistogram.length > 0 && (
+              <section className="yir-section">
+                <h2 className="yir-section-title">Rating distribution</h2>
+                <div className="yir-chart-wrap">
+                  <ResponsiveContainer width="100%" height={240}>
+                    <BarChart data={recap.ratingHistogram}>
+                      <CartesianGrid strokeDasharray="3 3" stroke="#2a2a2a" />
+                      <XAxis dataKey="rating" stroke="#888888" fontSize={11} />
+                      <YAxis
+                        stroke="#888888"
+                        fontSize={11}
+                        allowDecimals={false}
+                      />
+                      <Tooltip
+                        contentStyle={{
+                          backgroundColor: "#1a1a1a",
+                          border: "1px solid #2a2a2a",
+                          borderRadius: "8px",
+                          color: "#ffffff",
+                        }}
+                      />
+                      <Bar
+                        dataKey="count"
+                        fill="#ea580c"
+                        radius={[4, 4, 0, 0]}
+                      />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </div>
+              </section>
+            )}
+
+            {genrePieData.length > 0 && (
+              <section className="yir-section">
+                <h2 className="yir-section-title">Top genres</h2>
+                <div className="yir-chart-wrap yir-chart-wrap--pie">
+                  <ResponsiveContainer width="100%" height={320}>
+                    <PieChart>
+                      <Pie
+                        data={genrePieData}
+                        cx="50%"
+                        cy="50%"
+                        labelLine={false}
+                        outerRadius={110}
+                        fill="#8884d8"
+                        dataKey="value"
+                        nameKey="name"
+                      >
+                        {genrePieData.map((entry, index) => (
+                          <Cell key={`cell-${index}`} fill={entry.color} />
+                        ))}
+                      </Pie>
+                      <Tooltip
+                        contentStyle={{
+                          backgroundColor: "#1a1a1a",
+                          border: "1px solid #2a2a2a",
+                          borderRadius: "8px",
+                          color: "#ffffff",
+                        }}
+                      />
+                      <Legend
+                        layout="horizontal"
+                        verticalAlign="bottom"
+                        align="center"
+                        wrapperStyle={{
+                          paddingTop: "16px",
+                          color: "#888888",
+                          fontSize: "12px",
+                        }}
+                      />
+                    </PieChart>
+                  </ResponsiveContainer>
+                </div>
+              </section>
+            )}
+
+            {moodBarData.length > 0 && (
+              <section className="yir-section">
+                <h2 className="yir-section-title">Top moods</h2>
+                <div className="yir-chart-wrap">
+                  <ResponsiveContainer width="100%" height={280}>
+                    <BarChart data={moodBarData} layout="vertical">
+                      <CartesianGrid strokeDasharray="3 3" stroke="#2a2a2a" />
+                      <XAxis
+                        type="number"
+                        stroke="#888888"
+                        fontSize={11}
+                        allowDecimals={false}
+                      />
+                      <YAxis
+                        type="category"
+                        dataKey="name"
+                        stroke="#888888"
+                        fontSize={11}
+                        width={100}
+                      />
+                      <Tooltip
+                        contentStyle={{
+                          backgroundColor: "#1a1a1a",
+                          border: "1px solid #2a2a2a",
+                          borderRadius: "8px",
+                          color: "#ffffff",
+                        }}
+                      />
+                      <Bar dataKey="count" radius={[0, 4, 4, 0]}>
+                        {moodBarData.map((entry) => (
+                          <Cell
+                            key={entry.moodId}
+                            fill={moodBarColor(entry.moodId)}
+                          />
+                        ))}
+                      </Bar>
+                    </BarChart>
+                  </ResponsiveContainer>
+                </div>
+              </section>
+            )}
+
+            <footer className="yir-footer">
+              <p className="yir-disclaimer">
+                Based on log dates (watch date when set, otherwise first logged
+                date). Manual watch-date editing coming soon.
+              </p>
+            </footer>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default YearInReviewPage;

--- a/src/utils/gemini.js
+++ b/src/utils/gemini.js
@@ -1,5 +1,13 @@
 import { GoogleGenerativeAI } from "@google/generative-ai";
 import { fetchGroqGenres, TMDB_GENRES } from "./groq";
+import {
+  ORACLE_PROVIDER_MAX_RETRIES,
+  ORACLE_PROVIDER_TIMEOUT_MS,
+  ensureOracleRecommendationShape,
+  getOracleFailureBucket,
+  isAbortLikeError,
+  shouldRetryOracleError,
+} from "./oracleReliability";
 
 // Initialize Gemini AI client
 
@@ -63,8 +71,6 @@ const OPENROUTER_MODELS = [
   "openai/gpt-4o-mini",
 ];
 
-const toErrorString = (error) =>
-  String(error?.message || error || "").toLowerCase();
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const extractStatusCode = (error) => {
@@ -74,6 +80,44 @@ const extractStatusCode = (error) => {
   return match ? Number.parseInt(match[1], 10) : null;
 };
 
+const createAbortError = (provider, reason = "Request aborted") => {
+  const error = withTaggedError(reason, provider, 499);
+  error.name = "AbortError";
+  error.isAbort = true;
+  return error;
+};
+
+const makeTimeoutError = (provider, timeoutMs) => {
+  const error = withTaggedError(
+    `${provider} timeout after ${timeoutMs}ms`,
+    provider,
+    408,
+  );
+  error.isTimeout = true;
+  return error;
+};
+
+const runWithSignalAndTimeout = (promiseFactory, provider, timeoutMs, signal) =>
+  new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(createAbortError(provider));
+      return;
+    }
+    const timer = timeoutMs
+      ? setTimeout(() => reject(makeTimeoutError(provider, timeoutMs)), timeoutMs)
+      : null;
+    const onAbort = () => reject(createAbortError(provider));
+    signal?.addEventListener("abort", onAbort, { once: true });
+    Promise.resolve()
+      .then(promiseFactory)
+      .then(resolve)
+      .catch(reject)
+      .finally(() => {
+        if (timer) clearTimeout(timer);
+        signal?.removeEventListener("abort", onAbort);
+      });
+  });
+
 const withTaggedError = (message, provider, status = null) => {
   const prefix = `[ORACLE:${provider}${status ? `:${status}` : ""}]`;
   const error = new Error(`${prefix} ${message}`);
@@ -82,22 +126,20 @@ const withTaggedError = (message, provider, status = null) => {
   return error;
 };
 
-const isRetryableGeminiError = (error) => {
-  const status = extractStatusCode(error);
-  if (status === 404) return false;
-  if (status === 429 || status === 500 || status === 503) return true;
-  const raw = toErrorString(error);
-  return raw.includes("high demand") || raw.includes("overloaded");
-};
+const isRetryableGeminiError = (error) => shouldRetryOracleError(error);
 
-const runWithRetries = async (fn, shouldRetry, maxAttempts = 3) => {
+const runWithRetries = async (fn, shouldRetry, maxAttempts = 1) => {
   let lastError;
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     try {
       return await fn(attempt);
     } catch (error) {
       lastError = error;
-      if (attempt === maxAttempts || !shouldRetry(error)) {
+      if (
+        attempt === maxAttempts ||
+        !shouldRetry(error) ||
+        isAbortLikeError(error)
+      ) {
         throw error;
       }
       const delayMs =
@@ -119,6 +161,7 @@ const runOpenRouterWithFallback = async (
   prompt,
   generationConfig,
   validator,
+  options = {},
 ) => {
   const openRouterApiKey = import.meta.env.VITE_OPENROUTER_API_KEY;
   if (!openRouterApiKey) {
@@ -135,30 +178,43 @@ const runOpenRouterWithFallback = async (
     const modelName = OPENROUTER_MODELS[i];
     try {
       const response = await runWithRetries(
-        async () =>
-          fetch(OPENROUTER_API_URL, {
-            method: "POST",
-            headers: {
-              Authorization: `Bearer ${openRouterApiKey}`,
-              "Content-Type": "application/json",
-              "HTTP-Referer": window.location.origin,
-              "X-Title": "Filmgraph Oracle",
-            },
-            body: JSON.stringify({
-              model: modelName,
-              response_format: { type: "json_object" },
-              messages: [
-                { role: "system", content: "Return valid JSON only." },
-                { role: "user", content: prompt },
-              ],
-              temperature: generationConfig?.temperature ?? 0.9,
-              max_tokens: generationConfig?.maxOutputTokens ?? 1200,
-            }),
-          }),
-        (error) => {
-          const status = extractStatusCode(error);
-          return status === 429 || status === 500 || status === 503;
+        async () => {
+          const controller = new AbortController();
+          const onAbort = () => controller.abort();
+          options.signal?.addEventListener("abort", onAbort, { once: true });
+          try {
+            return await runWithSignalAndTimeout(
+              () =>
+                fetch(OPENROUTER_API_URL, {
+                  method: "POST",
+                  headers: {
+                    Authorization: `Bearer ${openRouterApiKey}`,
+                    "Content-Type": "application/json",
+                    "HTTP-Referer": window.location.origin,
+                    "X-Title": "Filmgraph Oracle",
+                  },
+                  signal: controller.signal,
+                  body: JSON.stringify({
+                    model: modelName,
+                    response_format: { type: "json_object" },
+                    messages: [
+                      { role: "system", content: "Return valid JSON only." },
+                      { role: "user", content: prompt },
+                    ],
+                    temperature: generationConfig?.temperature ?? 0.9,
+                    max_tokens: generationConfig?.maxOutputTokens ?? 1200,
+                  }),
+                }),
+              "openrouter",
+              ORACLE_PROVIDER_TIMEOUT_MS.openrouter,
+              options.signal,
+            );
+          } finally {
+            options.signal?.removeEventListener("abort", onAbort);
+          }
         },
+        shouldRetryOracleError,
+        ORACLE_PROVIDER_MAX_RETRIES.openrouter + 1,
       );
 
       if (!response.ok) {
@@ -171,17 +227,31 @@ const runOpenRouterWithFallback = async (
 
       const data = await response.json();
       const message = data?.choices?.[0]?.message?.content;
-      const parsed = parseJsonResponse(message);
+      let parsed;
+      try {
+        parsed = parseJsonResponse(message);
+      } catch (_parseErr) {
+        const parseError = withTaggedError(
+          "OpenRouter parse failure",
+          "openrouter",
+          422,
+        );
+        parseError.failureBucket = "parse_fail";
+        throw parseError;
+      }
       if (validator) validator(parsed);
       return { parsed, modelUsed: modelName };
     } catch (error) {
       lastError = error;
+      if (isAbortLikeError(error)) throw error;
       if (i === OPENROUTER_MODELS.length - 1) {
-        throw withTaggedError(
+        const taggedError = withTaggedError(
           error.message || "OpenRouter failure",
           "openrouter",
           extractStatusCode(error),
         );
+        taggedError.failureBucket = getOracleFailureBucket(error);
+        throw taggedError;
       }
       console.warn(
         `⚠️ OpenRouter model failed (${modelName}). Trying next model.`,
@@ -196,7 +266,12 @@ const runOpenRouterWithFallback = async (
   );
 };
 
-const runGeminiWithFallback = async (prompt, generationConfig, validator) => {
+const runGeminiWithFallback = async (
+  prompt,
+  generationConfig,
+  validator,
+  options = {},
+) => {
   if (!genAI) {
     throw withTaggedError(
       "Gemini unavailable: missing VITE_GEMINI_API_KEY",
@@ -212,34 +287,53 @@ const runGeminiWithFallback = async (prompt, generationConfig, validator) => {
 
     try {
       const chunks = await runWithRetries(async () => {
-        const model = genAI.getGenerativeModel({
-          model: modelName,
-          generationConfig,
-        });
-        const result = await model.generateContentStream(prompt);
-        const streamed = [];
-        for await (const chunk of result.stream) {
-          streamed.push(chunk.text());
-        }
-        return streamed;
-      }, isRetryableGeminiError);
+        return runWithSignalAndTimeout(
+          async () => {
+            if (options.signal?.aborted) throw createAbortError("gemini");
+            const model = genAI.getGenerativeModel({
+              model: modelName,
+              generationConfig,
+            });
+            const result = await model.generateContentStream(prompt);
+            const streamed = [];
+            for await (const chunk of result.stream) {
+              if (options.signal?.aborted) throw createAbortError("gemini");
+              streamed.push(chunk.text());
+            }
+            return streamed;
+          },
+          "gemini",
+          ORACLE_PROVIDER_TIMEOUT_MS.gemini,
+          options.signal,
+        );
+      }, isRetryableGeminiError, ORACLE_PROVIDER_MAX_RETRIES.gemini + 1);
 
-      const parsed = parseJsonResponse(chunks.join(""));
+      let parsed;
+      try {
+        parsed = parseJsonResponse(chunks.join(""));
+      } catch (_parseErr) {
+        const parseError = withTaggedError("Gemini parse failure", "gemini", 422);
+        parseError.failureBucket = "parse_fail";
+        throw parseError;
+      }
       if (validator) validator(parsed);
 
       return { parsed, modelUsed: modelName };
     } catch (error) {
       lastError = error;
+      if (isAbortLikeError(error)) throw error;
       const status = extractStatusCode(error);
       if (
         i === GEMINI_MODEL_CANDIDATES.length - 1 ||
         (!isRetryableGeminiError(error) && status !== 404)
       ) {
-        throw withTaggedError(
+        const taggedError = withTaggedError(
           error.message || "Gemini request failed",
           "gemini",
           status,
         );
+        taggedError.failureBucket = getOracleFailureBucket(error);
+        throw taggedError;
       }
       console.warn(`⚠️ Gemini model failed (${modelName}). Trying next model.`);
     }
@@ -259,10 +353,132 @@ const getLocalVibeCheck = (vibe) => {
   return `${words}${words.length < trimmed.length ? "..." : ""}`;
 };
 
+const normalizeTitle = (title) =>
+  String(title || "")
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim();
+
+const normalizeYear = (year) => {
+  if (year == null) return "";
+  const parsed = Number.parseInt(String(year), 10);
+  return Number.isFinite(parsed) ? String(parsed) : "";
+};
+
+const buildRecommendationKey = (title, year) =>
+  `${normalizeTitle(title)}::${normalizeYear(year)}`;
+
+const hasYearConstraint = (constraints) =>
+  Number.isFinite(constraints?.yearMin) || Number.isFinite(constraints?.yearMax);
+
+const recommendationMeetsConstraints = (rec, queryConstraints) => {
+  if (!queryConstraints?.hasConstraints) return true;
+
+  if (hasYearConstraint(queryConstraints)) {
+    const parsedYear = Number.parseInt(String(rec?.year || ""), 10);
+    if (!Number.isFinite(parsedYear)) return false;
+    if (
+      Number.isFinite(queryConstraints.yearMin) &&
+      parsedYear < queryConstraints.yearMin
+    ) {
+      return false;
+    }
+    if (
+      Number.isFinite(queryConstraints.yearMax) &&
+      parsedYear > queryConstraints.yearMax
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const sanitizeRecommendations = (
+  recommendations,
+  rejectedTitles = [],
+  queryConstraints = null,
+) => {
+  const rejectedSet = new Set(rejectedTitles.map((title) => normalizeTitle(title)));
+  const seen = new Set();
+  const cleaned = [];
+
+  for (const rec of recommendations || []) {
+    if (!rec || typeof rec !== "object") continue;
+    const title = String(rec.title || "").trim();
+    if (!title) continue;
+
+    const normalizedTitle = normalizeTitle(title);
+    if (!normalizedTitle || rejectedSet.has(normalizedTitle)) continue;
+
+    const year = normalizeYear(rec.year);
+    const key = buildRecommendationKey(title, year);
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    cleaned.push({
+      title,
+      year: year ? Number.parseInt(year, 10) : null,
+      rationale: String(rec.rationale || "").trim() || "Curated for your current vibe and taste profile.",
+      vibeCheck: String(rec.vibeCheck || "").trim() || getLocalVibeCheck(""),
+    });
+  }
+
+  return cleaned.filter((rec) =>
+    recommendationMeetsConstraints(rec, queryConstraints),
+  );
+};
+
+const ensureRecommendationQuality = async ({
+  recommendations,
+  vibe,
+  rejectedTitles = [],
+  genreIds = [],
+  queryConstraints = null,
+  signal = null,
+}) => {
+  const MIN_RECOMMENDATIONS = 3;
+  const MAX_RECOMMENDATIONS = 5;
+
+  let cleaned = sanitizeRecommendations(
+    recommendations,
+    rejectedTitles,
+    queryConstraints,
+  ).slice(0, MAX_RECOMMENDATIONS);
+
+  if (cleaned.length < MIN_RECOMMENDATIONS) {
+    try {
+      const fallback = await buildTmdbFallbackRecommendations(
+        vibe,
+        genreIds,
+        rejectedTitles,
+        queryConstraints,
+        { signal },
+      );
+      const merged = sanitizeRecommendations(
+        [...cleaned, ...fallback],
+        rejectedTitles,
+        queryConstraints,
+      );
+      cleaned = merged.slice(0, MAX_RECOMMENDATIONS);
+    } catch (_fallbackError) {
+      // Keep existing cleaned results if fallback cannot top up.
+    }
+  }
+
+  if (cleaned.length === 0) {
+    throw new Error("No valid recommendations after filtering.");
+  }
+
+  return cleaned;
+};
+
 const buildTmdbFallbackRecommendations = async (
   vibe,
   genreIds,
   rejectedTitles = [],
+  queryConstraints = null,
+  options = {},
 ) => {
   const tmdbApiKey = import.meta.env.VITE_TMDB_API_KEY;
   if (!tmdbApiKey) {
@@ -272,20 +488,41 @@ const buildTmdbFallbackRecommendations = async (
   const rejected = new Set(
     rejectedTitles.map((t) => String(t || "").toLowerCase()),
   );
-  const uniqueGenreIds = (genreIds || []).filter(Boolean);
+  const uniqueGenreIds = [
+    ...new Set([...(queryConstraints?.genreIds || []), ...(genreIds || [])]),
+  ].filter(Boolean);
   const genreParam =
     uniqueGenreIds.length > 0 ? `&with_genres=${uniqueGenreIds.join("|")}` : "";
+  const yearMinParam = Number.isFinite(queryConstraints?.yearMin)
+    ? `&primary_release_date.gte=${queryConstraints.yearMin}-01-01`
+    : "";
+  const yearMaxParam = Number.isFinite(queryConstraints?.yearMax)
+    ? `&primary_release_date.lte=${queryConstraints.yearMax}-12-31`
+    : "";
   const page = 1 + Math.floor(Math.random() * 3);
 
   const response = await runWithRetries(
-    async () =>
-      fetch(
-        `https://api.themoviedb.org/3/discover/movie?api_key=${tmdbApiKey}&include_adult=false&sort_by=vote_average.desc&vote_count.gte=300&page=${page}${genreParam}`,
-      ),
-    (error) => {
-      const status = extractStatusCode(error);
-      return status === 429 || status === 500 || status === 503;
+    async () => {
+      const controller = new AbortController();
+      const onAbort = () => controller.abort();
+      options.signal?.addEventListener("abort", onAbort, { once: true });
+      try {
+        return await runWithSignalAndTimeout(
+          () =>
+            fetch(
+              `https://api.themoviedb.org/3/discover/movie?api_key=${tmdbApiKey}&include_adult=false&sort_by=vote_average.desc&vote_count.gte=300&page=${page}${genreParam}${yearMinParam}${yearMaxParam}`,
+              { signal: controller.signal },
+            ),
+          "tmdb",
+          ORACLE_PROVIDER_TIMEOUT_MS.tmdb,
+          options.signal,
+        );
+      } finally {
+        options.signal?.removeEventListener("abort", onAbort);
+      }
     },
+    shouldRetryOracleError,
+    ORACLE_PROVIDER_MAX_RETRIES.tmdb + 1,
   );
 
   if (!response.ok) {
@@ -297,7 +534,8 @@ const buildTmdbFallbackRecommendations = async (
   }
 
   const data = await response.json();
-  const picks = (data?.results || [])
+  const picks = ensureOracleRecommendationShape(
+    (data?.results || [])
     .filter(
       (movie) =>
         movie?.title && !rejected.has(String(movie.title).toLowerCase()),
@@ -310,7 +548,8 @@ const buildTmdbFallbackRecommendations = async (
         : null,
       rationale: `Gemini is currently unavailable, so this pick is sourced from TMDB based on your vibe and genre fit. ${movie.title} has strong audience reception and should align with your current request.`,
       vibeCheck: getLocalVibeCheck(vibe),
-    }));
+    })),
+  );
 
   if (picks.length === 0) {
     throw withTaggedError(
@@ -322,6 +561,35 @@ const buildTmdbFallbackRecommendations = async (
 
   return picks;
 };
+
+const buildConstraintPromptBlock = (queryConstraints) => {
+  if (!queryConstraints?.hasConstraints) return "";
+
+  const lines = [];
+  if (Number.isFinite(queryConstraints.yearMin)) {
+    lines.push(`- Release year must be >= ${queryConstraints.yearMin}`);
+  }
+  if (Number.isFinite(queryConstraints.yearMax)) {
+    lines.push(`- Release year must be <= ${queryConstraints.yearMax}`);
+  }
+  if (queryConstraints.watchStatus === "to-watch") {
+    lines.push("- Prioritize picks that align with watchlist intent and avoid already-seen framing.");
+  } else if (queryConstraints.watchStatus === "watched") {
+    lines.push("- Prioritize fresh watched-style discoveries rather than watchlist-oriented picks.");
+  }
+  if (Array.isArray(queryConstraints.genreNames) && queryConstraints.genreNames.length > 0) {
+    lines.push(`- Genre focus: ${queryConstraints.genreNames.join(", ")}`);
+  }
+
+  if (lines.length === 0) return "";
+  return `\n\nQUERY CONSTRAINTS (STRICT):\n${lines.join("\n")}`;
+};
+
+const ORACLE_TASTE_CONTEXT_RULES = `\n\nTASTE CONTEXT INTERPRETATION (APPLIES TO ALL PROVIDERS):
+- Treat USER CONTEXT lines (TopMoods, TopGenres, MoodAffinityWeighted, GenreAffinityWeighted, LovedTitles, AvoidSimilarTo, RecentWatched, RecentToWatch, CuratedLists) as weighted signals.
+- Prioritize alignment with LovedTitles + weighted mood/genre affinity.
+- Use AvoidSimilarTo as an advisory penalty (strongly discourage close tonal matches), not an absolute ban.
+- Keep recommendations diverse enough to avoid overfitting to only the newest entries while still respecting RecentWatched/RecentToWatch context.`;
 
 /**
  * Get AI-powered movie recommendations with caching
@@ -612,6 +880,8 @@ export const getHybridRecommendation = async (vibe, options = {}) => {
     userContext = "No favorite films provided",
     systemPrompt = BASE_SYSTEM_PROMPT,
     rejectedTitles = [],
+    queryConstraints = null,
+    signal = null,
   } = options;
 
   const rejectedContext =
@@ -620,6 +890,7 @@ export const getHybridRecommendation = async (vibe, options = {}) => {
       : "";
 
   const fullSystemPrompt = `${systemPrompt}${rejectedContext}`;
+  const constraintPromptBlock = buildConstraintPromptBlock(queryConstraints);
 
   let genreIds = [];
   let groqSuccess = false;
@@ -638,6 +909,10 @@ export const getHybridRecommendation = async (vibe, options = {}) => {
     );
   }
 
+  if (Array.isArray(queryConstraints?.genreIds) && queryConstraints.genreIds.length > 0) {
+    genreIds = [...new Set([...queryConstraints.genreIds, ...genreIds])];
+  }
+
   const genreContext =
     groqSuccess && genreIds.length > 0
       ? `\n\nEXTRACTED GENRE IDS: [${genreIds.join(", ")}]
@@ -651,7 +926,7 @@ USER CONTEXT (Curated Favorites):
 ${userContext}
 
 CURRENT MOOD/REQUEST:
-"${vibe}"${genreContext}
+"${vibe}"${genreContext}${constraintPromptBlock}
 
 CRITICAL REQUIREMENTS:
 1. Return EXACTLY 3 to 5 unique movies - no more, no less
@@ -673,6 +948,8 @@ Your job is to suggest NEW discoveries they haven't logged yet.`
 
 🎯 TASTE TRIANGULATION:
 Use the USER CONTEXT above to understand their niche interests. If they love atmospheric horror, don't suggest slapstick comedy. If they appreciate slow-burn indie dramas, don't recommend Michael Bay. Match their aesthetic while expanding their horizons.
+
+${ORACLE_TASTE_CONTEXT_RULES}
 
 Return ONLY valid JSON. NO text before or after. NO markdown formatting.
 
@@ -705,10 +982,20 @@ Format:
           throw new Error("Invalid response format from Gemini");
         }
       },
+      { signal },
     );
 
-    return {
+    const smartRecommendations = await ensureRecommendationQuality({
       recommendations: parsed.recommendations,
+      vibe,
+      rejectedTitles,
+      genreIds,
+      queryConstraints,
+      signal,
+    });
+
+    return {
+      recommendations: smartRecommendations,
       _meta: {
         provider: "gemini",
         groqUsed: groqSuccess,
@@ -720,6 +1007,7 @@ Format:
       },
     };
   } catch (error) {
+    if (isAbortLikeError(error)) throw error;
     console.error("❌ Hybrid recommendation failed:", error.message);
 
     try {
@@ -738,10 +1026,20 @@ Format:
             throw new Error("Invalid response format from OpenRouter");
           }
         },
+        { signal },
       );
 
-      return {
+      const smartRecommendations = await ensureRecommendationQuality({
         recommendations: parsed.recommendations,
+        vibe,
+        rejectedTitles,
+        genreIds,
+        queryConstraints,
+        signal,
+      });
+
+      return {
+        recommendations: smartRecommendations,
         _meta: {
           provider: "openrouter",
           groqUsed: groqSuccess,
@@ -752,6 +1050,7 @@ Format:
         },
       };
     } catch (openRouterError) {
+      if (isAbortLikeError(openRouterError)) throw openRouterError;
       console.warn("⚠️ OpenRouter fallback failed:", openRouterError.message);
     }
 
@@ -760,6 +1059,8 @@ Format:
         vibe,
         genreIds,
         rejectedTitles,
+        queryConstraints,
+        { signal },
       );
       return {
         recommendations: fallbackRecommendations,
@@ -773,6 +1074,7 @@ Format:
         },
       };
     } catch (fallbackError) {
+      if (isAbortLikeError(fallbackError)) throw fallbackError;
       console.error("❌ TMDB fallback failed:", fallbackError.message);
       throw withTaggedError(
         "All recommendation providers are unavailable. Please try again shortly.",

--- a/src/utils/gemini.js
+++ b/src/utils/gemini.js
@@ -368,6 +368,18 @@ const normalizeYear = (year) => {
 const buildRecommendationKey = (title, year) =>
   `${normalizeTitle(title)}::${normalizeYear(year)}`;
 
+const toNonNegativeInt = (value, fallback = 0) => {
+  const parsed = Number.parseInt(String(value), 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return fallback;
+  return parsed;
+};
+
+const cleanAttemptText = (value) => {
+  if (value == null) return null;
+  const trimmed = String(value).trim();
+  return trimmed ? trimmed.slice(0, 120) : null;
+};
+
 const hasYearConstraint = (constraints) =>
   Number.isFinite(constraints?.yearMin) || Number.isFinite(constraints?.yearMax);
 
@@ -399,21 +411,31 @@ const sanitizeRecommendations = (
   rejectedTitles = [],
   queryConstraints = null,
 ) => {
+  const source = Array.isArray(recommendations) ? recommendations : [];
   const rejectedSet = new Set(rejectedTitles.map((title) => normalizeTitle(title)));
   const seen = new Set();
   const cleaned = [];
+  let dedupeDroppedCount = 0;
+  let rejectedViolationAttemptCount = 0;
 
-  for (const rec of recommendations || []) {
+  for (const rec of source) {
     if (!rec || typeof rec !== "object") continue;
     const title = String(rec.title || "").trim();
     if (!title) continue;
 
     const normalizedTitle = normalizeTitle(title);
-    if (!normalizedTitle || rejectedSet.has(normalizedTitle)) continue;
+    if (!normalizedTitle) continue;
+    if (rejectedSet.has(normalizedTitle)) {
+      rejectedViolationAttemptCount += 1;
+      continue;
+    }
 
     const year = normalizeYear(rec.year);
     const key = buildRecommendationKey(title, year);
-    if (seen.has(key)) continue;
+    if (seen.has(key)) {
+      dedupeDroppedCount += 1;
+      continue;
+    }
     seen.add(key);
 
     cleaned.push({
@@ -424,9 +446,16 @@ const sanitizeRecommendations = (
     });
   }
 
-  return cleaned.filter((rec) =>
-    recommendationMeetsConstraints(rec, queryConstraints),
-  );
+  return {
+    recommendations: cleaned.filter((rec) =>
+      recommendationMeetsConstraints(rec, queryConstraints),
+    ),
+    metrics: {
+      inputRecommendationCount: source.length,
+      dedupeDroppedCount,
+      rejectedViolationAttemptCount,
+    },
+  };
 };
 
 const ensureRecommendationQuality = async ({
@@ -440,11 +469,15 @@ const ensureRecommendationQuality = async ({
   const MIN_RECOMMENDATIONS = 3;
   const MAX_RECOMMENDATIONS = 5;
 
-  let cleaned = sanitizeRecommendations(
+  const initialSanitize = sanitizeRecommendations(
     recommendations,
     rejectedTitles,
     queryConstraints,
-  ).slice(0, MAX_RECOMMENDATIONS);
+  );
+  let cleaned = initialSanitize.recommendations.slice(0, MAX_RECOMMENDATIONS);
+  let dedupeDroppedCount = initialSanitize.metrics.dedupeDroppedCount;
+  let rejectedViolationAttemptCount =
+    initialSanitize.metrics.rejectedViolationAttemptCount;
 
   if (cleaned.length < MIN_RECOMMENDATIONS) {
     try {
@@ -460,7 +493,10 @@ const ensureRecommendationQuality = async ({
         rejectedTitles,
         queryConstraints,
       );
-      cleaned = merged.slice(0, MAX_RECOMMENDATIONS);
+      dedupeDroppedCount += merged.metrics.dedupeDroppedCount;
+      rejectedViolationAttemptCount +=
+        merged.metrics.rejectedViolationAttemptCount;
+      cleaned = merged.recommendations.slice(0, MAX_RECOMMENDATIONS);
     } catch (_fallbackError) {
       // Keep existing cleaned results if fallback cannot top up.
     }
@@ -470,7 +506,17 @@ const ensureRecommendationQuality = async ({
     throw new Error("No valid recommendations after filtering.");
   }
 
-  return cleaned;
+  return {
+    recommendations: cleaned,
+    qualityMetrics: {
+      inputRecommendationCount: initialSanitize.metrics.inputRecommendationCount,
+      postFilterRecommendationCount: cleaned.length,
+      dedupeDroppedCount: toNonNegativeInt(dedupeDroppedCount),
+      rejectedViolationAttemptCount: toNonNegativeInt(
+        rejectedViolationAttemptCount,
+      ),
+    },
+  };
 };
 
 const buildTmdbFallbackRecommendations = async (
@@ -894,7 +940,46 @@ export const getHybridRecommendation = async (vibe, options = {}) => {
 
   let genreIds = [];
   let groqSuccess = false;
-  let startTime = performance.now();
+  const startTime = performance.now();
+  let geminiAttemptStart = null;
+  let openRouterAttemptStart = null;
+  let tmdbAttemptStart = null;
+  const providerAttempts = [];
+  const pushAttempt = ({
+    provider,
+    model,
+    result,
+    status = null,
+    failureBucket = null,
+    attemptStartTime = null,
+  }) => {
+    const latencyMs =
+      typeof attemptStartTime === "number"
+        ? Math.max(0, Math.round(performance.now() - attemptStartTime))
+        : null;
+    providerAttempts.push({
+      provider: cleanAttemptText(provider),
+      model: cleanAttemptText(model),
+      result: cleanAttemptText(result) || "unknown",
+      status: cleanAttemptText(status),
+      failure_bucket: cleanAttemptText(failureBucket),
+      latency_ms: latencyMs,
+    });
+  };
+  const buildAttemptMetrics = (successProvider = null) => {
+    const successIndex = providerAttempts.findIndex(
+      (attempt) => attempt.provider === successProvider && attempt.result === "success",
+    );
+    const providerAttemptCount = providerAttempts.length;
+    return {
+      providerAttemptCount,
+      fallbackDepth:
+        successIndex >= 0
+          ? successIndex
+          : Math.max(0, providerAttemptCount > 0 ? providerAttemptCount - 1 : 0),
+      providerAttempts,
+    };
+  };
 
   // Step 1: Try Groq for fast genre extraction (target: sub-500ms)
   try {
@@ -966,6 +1051,7 @@ Format:
 }`;
 
   try {
+    geminiAttemptStart = performance.now();
     const { parsed, modelUsed } = await runGeminiWithFallback(
       prompt,
       {
@@ -984,15 +1070,23 @@ Format:
       },
       { signal },
     );
-
-    const smartRecommendations = await ensureRecommendationQuality({
-      recommendations: parsed.recommendations,
-      vibe,
-      rejectedTitles,
-      genreIds,
-      queryConstraints,
-      signal,
+    pushAttempt({
+      provider: "gemini",
+      model: modelUsed,
+      result: "success",
+      status: "ok",
+      attemptStartTime: geminiAttemptStart,
     });
+
+    const { recommendations: smartRecommendations, qualityMetrics } =
+      await ensureRecommendationQuality({
+        recommendations: parsed.recommendations,
+        vibe,
+        rejectedTitles,
+        genreIds,
+        queryConstraints,
+        signal,
+      });
 
     return {
       recommendations: smartRecommendations,
@@ -1004,13 +1098,24 @@ Format:
         latency: groqSuccess
           ? `${Math.round(performance.now() - startTime)}ms`
           : "fallback",
+        qualityMetrics,
+        attemptMetrics: buildAttemptMetrics("gemini"),
       },
     };
   } catch (error) {
     if (isAbortLikeError(error)) throw error;
+    pushAttempt({
+      provider: "gemini",
+      model: null,
+      result: "failure",
+      status: extractStatusCode(error),
+      failureBucket: getOracleFailureBucket(error),
+      attemptStartTime: geminiAttemptStart,
+    });
     console.error("❌ Hybrid recommendation failed:", error.message);
 
     try {
+      openRouterAttemptStart = performance.now();
       const { parsed, modelUsed } = await runOpenRouterWithFallback(
         prompt,
         {
@@ -1028,15 +1133,23 @@ Format:
         },
         { signal },
       );
-
-      const smartRecommendations = await ensureRecommendationQuality({
-        recommendations: parsed.recommendations,
-        vibe,
-        rejectedTitles,
-        genreIds,
-        queryConstraints,
-        signal,
+      pushAttempt({
+        provider: "openrouter",
+        model: modelUsed,
+        result: "success",
+        status: "ok",
+        attemptStartTime: openRouterAttemptStart,
       });
+
+      const { recommendations: smartRecommendations, qualityMetrics } =
+        await ensureRecommendationQuality({
+          recommendations: parsed.recommendations,
+          vibe,
+          rejectedTitles,
+          genreIds,
+          queryConstraints,
+          signal,
+        });
 
       return {
         recommendations: smartRecommendations,
@@ -1047,14 +1160,25 @@ Format:
           modelUsed,
           latency: `${Math.round(performance.now() - startTime)}ms`,
           fallbackReason: "gemini_unavailable",
+          qualityMetrics,
+          attemptMetrics: buildAttemptMetrics("openrouter"),
         },
       };
     } catch (openRouterError) {
       if (isAbortLikeError(openRouterError)) throw openRouterError;
+      pushAttempt({
+        provider: "openrouter",
+        model: null,
+        result: "failure",
+        status: extractStatusCode(openRouterError),
+        failureBucket: getOracleFailureBucket(openRouterError),
+        attemptStartTime: openRouterAttemptStart,
+      });
       console.warn("⚠️ OpenRouter fallback failed:", openRouterError.message);
     }
 
     try {
+      tmdbAttemptStart = performance.now();
       const fallbackRecommendations = await buildTmdbFallbackRecommendations(
         vibe,
         genreIds,
@@ -1062,8 +1186,26 @@ Format:
         queryConstraints,
         { signal },
       );
-      return {
+      pushAttempt({
+        provider: "tmdb",
+        model: "tmdb-fallback",
+        result: "success",
+        status: "ok",
+        attemptStartTime: tmdbAttemptStart,
+      });
+      const {
+        recommendations: qualityCheckedFallbackRecommendations,
+        qualityMetrics,
+      } = await ensureRecommendationQuality({
         recommendations: fallbackRecommendations,
+        vibe,
+        rejectedTitles,
+        genreIds,
+        queryConstraints,
+        signal,
+      });
+      return {
+        recommendations: qualityCheckedFallbackRecommendations,
         _meta: {
           provider: "tmdb",
           groqUsed: groqSuccess,
@@ -1071,16 +1213,34 @@ Format:
           modelUsed: "tmdb-fallback",
           latency: `${Math.round(performance.now() - startTime)}ms`,
           fallbackReason: "gemini_unavailable",
+          qualityMetrics,
+          attemptMetrics: buildAttemptMetrics("tmdb"),
         },
       };
     } catch (fallbackError) {
       if (isAbortLikeError(fallbackError)) throw fallbackError;
+      pushAttempt({
+        provider: "tmdb",
+        model: "tmdb-fallback",
+        result: "failure",
+        status: extractStatusCode(fallbackError),
+        failureBucket: getOracleFailureBucket(fallbackError),
+        attemptStartTime: tmdbAttemptStart,
+      });
       console.error("❌ TMDB fallback failed:", fallbackError.message);
-      throw withTaggedError(
+      const orchestrationError = withTaggedError(
         "All recommendation providers are unavailable. Please try again shortly.",
         "orchestration",
         extractStatusCode(fallbackError),
       );
+      orchestrationError.oracleMeta = {
+        provider: "orchestration",
+        groqUsed: groqSuccess,
+        genreIds,
+        fallbackReason: "all_providers_unavailable",
+        attemptMetrics: buildAttemptMetrics(null),
+      };
+      throw orchestrationError;
     }
   }
 };

--- a/src/utils/gemini.js
+++ b/src/utils/gemini.js
@@ -54,9 +54,13 @@ if (!apiKey) {
 
 const genAI = apiKey ? new GoogleGenerativeAI(apiKey) : null;
 
-// Keep a model ladder because Google model availability can change per key/project.
+// Model ladder: Google availability varies by key/project. Order is latency-first for Oracle —
+// `gemini-2.0-flash` tends to answer faster than leading with 3.1; if 2.0 errors/unavailable,
+// we still try `gemini-3.1-flash-lite` and older IDs before giving up (avoids paying a slow or
+// failed first attempt then full timeout on the next slot).
 const GEMINI_MODEL_CANDIDATES = [
   "gemini-2.0-flash",
+  "gemini-3.1-flash-lite",
   "gemini-2.0-flash-lite",
   "gemini-1.5-flash-latest",
   "gemini-1.5-pro-latest",

--- a/src/utils/groq.js
+++ b/src/utils/groq.js
@@ -108,3 +108,119 @@ NO text, NO explanation.`;
     throw error;
   }
 };
+
+const normalizeOracleIntentPayload = (payload, fallbackPrompt = "") => {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+
+  const normalizedGenreIds = [...new Set((payload.genreIds || [])
+    .map((id) => Number.parseInt(String(id), 10))
+    .filter((id) => Number.isFinite(id) && TMDB_GENRES[id]))];
+  const normalizedGenreNames = [...new Set((payload.genreNames || [])
+    .map((name) => String(name || "").trim().toLowerCase())
+    .filter(Boolean))];
+
+  const safeYearMin = Number.isFinite(Number(payload.yearMin)) ? Number(payload.yearMin) : null;
+  const safeYearMax = Number.isFinite(Number(payload.yearMax)) ? Number(payload.yearMax) : null;
+  const safeWatchStatus =
+    payload.watchStatus === "watched" || payload.watchStatus === "to-watch"
+      ? payload.watchStatus
+      : null;
+  const strippedPrompt =
+    typeof payload.strippedPrompt === "string" ? payload.strippedPrompt.trim() : String(fallbackPrompt || "").trim();
+
+  return {
+    normalizedText: String(fallbackPrompt || "").trim().toLowerCase(),
+    yearMin: safeYearMin,
+    yearMax: safeYearMax,
+    watchStatus: safeWatchStatus,
+    genreIds: normalizedGenreIds,
+    genreNames: normalizedGenreNames,
+    hasConstraints: Boolean(
+      safeWatchStatus || Number.isFinite(safeYearMin) || Number.isFinite(safeYearMax) || normalizedGenreIds.length > 0
+    ),
+    strippedPrompt,
+  };
+};
+
+/**
+ * Parse Oracle query constraints with Groq for low-latency intent extraction.
+ * Returns strict normalized JSON used by Oracle query filtering.
+ *
+ * @param {string} prompt - User discovery prompt
+ * @returns {Promise<Object>} - Oracle constraints object
+ */
+export const parseOracleIntentWithGroq = async (prompt) => {
+  if (!GROQ_API_KEY) {
+    throw new Error("VITE_GROQ_API_KEY is not configured");
+  }
+
+  const userPrompt = String(prompt || "").trim();
+  if (!userPrompt) {
+    return {
+      normalizedText: "",
+      yearMin: null,
+      yearMax: null,
+      watchStatus: null,
+      genreIds: [],
+      genreNames: [],
+      hasConstraints: false,
+      strippedPrompt: "",
+    };
+  }
+
+  const systemPrompt = `You are a strict JSON intent parser for Filmgraph Oracle.
+Extract only query constraints from the user prompt.
+
+Allowed fields and exact JSON shape:
+{
+  "yearMin": null | number,
+  "yearMax": null | number,
+  "watchStatus": null | "watched" | "to-watch",
+  "genreIds": number[],
+  "genreNames": string[],
+  "strippedPrompt": string
+}
+
+Rules:
+- If user asks for pre/before year, set yearMax accordingly.
+- If user asks for after/post year, set yearMin accordingly.
+- If no explicit constraint exists, use null/empty arrays.
+- Always return valid JSON only.`;
+
+  const response = await fetch(GROQ_API_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${GROQ_API_KEY}`,
+    },
+    body: JSON.stringify({
+      model: "llama-3.3-70b-versatile",
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: userPrompt },
+      ],
+      temperature: 0.0,
+      max_tokens: 120,
+      response_format: { type: "json_object" },
+    }),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(errorData.error?.message || `Groq intent parser error: ${response.status}`);
+  }
+
+  const data = await response.json();
+  const content = data?.choices?.[0]?.message?.content;
+  if (!content) {
+    throw new Error("Groq intent parser returned empty response");
+  }
+  const parsed = JSON.parse(content);
+  const normalized = normalizeOracleIntentPayload(parsed, userPrompt);
+  if (!normalized) {
+    throw new Error("Groq intent parser returned invalid payload");
+  }
+  return normalized;
+};

--- a/src/utils/libraryAdvancedSearch.js
+++ b/src/utils/libraryAdvancedSearch.js
@@ -1,0 +1,50 @@
+/**
+ * Helpers for Library advanced search (mood, genre, rating filters).
+ */
+
+export function normalizeNlMoodToken(token) {
+  if (!token) return '';
+  const t = String(token).toLowerCase();
+  const map = {
+    'mind-bending': 'mindbending',
+  };
+  return map[t] || t;
+}
+
+export function movieMatchesMoodFilter(movie, moodIds, mode) {
+  if (!moodIds?.length) return true;
+  const mm = movie.moods || [];
+  if (mode === 'all') return moodIds.every((id) => mm.includes(id));
+  return moodIds.some((id) => mm.includes(id));
+}
+
+export function movieMatchesGenreFilter(movie, selectedGenres) {
+  if (!selectedGenres?.length) return true;
+  const mg = (movie.genres || []).map((g) => String(g).toLowerCase().trim());
+  return selectedGenres.every((want) => {
+    const w = want.toLowerCase();
+    return mg.some((x) => x === w || x.includes(w));
+  });
+}
+
+export function movieMatchesRatingFilter(movie, minR, maxR) {
+  let minNum = minR !== '' && minR != null && Number.isFinite(Number(minR)) ? Number(minR) : null;
+  let maxNum = maxR !== '' && maxR != null && Number.isFinite(Number(maxR)) ? Number(maxR) : null;
+  if (minNum != null && maxNum != null && minNum > maxNum) {
+    const t = minNum;
+    minNum = maxNum;
+    maxNum = t;
+  }
+
+  const hasMin = minNum != null;
+  const hasMax = maxNum != null;
+  if (!hasMin && !hasMax) return true;
+
+  const raw = movie.rating;
+  if (raw == null || !Number.isFinite(Number(raw))) return false;
+
+  const r = Number(raw);
+  if (hasMin && r < minNum) return false;
+  if (hasMax && r > maxNum) return false;
+  return true;
+}

--- a/src/utils/naturalLanguageSort.js
+++ b/src/utils/naturalLanguageSort.js
@@ -9,6 +9,53 @@ const STATUS_HINTS = [
   { pattern: /\bwatched|seen\b/i, status: 'watched' },
 ];
 
+const ORACLE_GENRE_HINTS = [
+  { pattern: /\bhorror\b/i, id: 27, name: 'horror' },
+  { pattern: /\bthriller\b/i, id: 53, name: 'thriller' },
+  { pattern: /\bcomedy\b/i, id: 35, name: 'comedy' },
+  { pattern: /\bdrama\b/i, id: 18, name: 'drama' },
+  { pattern: /\bromance|romantic\b/i, id: 10749, name: 'romance' },
+  { pattern: /\bscience fiction|sci[- ]?fi\b/i, id: 878, name: 'science fiction' },
+  { pattern: /\banimation|animated\b/i, id: 16, name: 'animation' },
+  { pattern: /\bcrime\b/i, id: 80, name: 'crime' },
+  { pattern: /\bdocumentary\b/i, id: 99, name: 'documentary' },
+  { pattern: /\bfantasy\b/i, id: 14, name: 'fantasy' },
+  { pattern: /\bmystery\b/i, id: 9648, name: 'mystery' },
+  { pattern: /\baction\b/i, id: 28, name: 'action' },
+];
+
+const getYearBounds = (text) => {
+  const betweenMatch = text.match(/\bbetween\s+(19\d{2}|20\d{2})\s+(?:and|to)\s+(19\d{2}|20\d{2})\b/i);
+  if (betweenMatch) {
+    const a = Number.parseInt(betweenMatch[1], 10);
+    const b = Number.parseInt(betweenMatch[2], 10);
+    return {
+      yearMin: Math.min(a, b),
+      yearMax: Math.max(a, b),
+    };
+  }
+
+  const beforeMatch = text.match(/\b(?:pre[-\s]?|before|older than)\s*(19\d{2}|20\d{2})(?:s)?\b/i);
+  if (beforeMatch) {
+    const year = Number.parseInt(beforeMatch[1], 10);
+    return { yearMin: null, yearMax: year - 1 };
+  }
+
+  const afterMatch = text.match(/\b(?:after|post|since)\s+(19\d{2}|20\d{2})(?:s)?\b/i);
+  if (afterMatch) {
+    const year = Number.parseInt(afterMatch[1], 10);
+    return { yearMin: year + 1, yearMax: null };
+  }
+
+  const decadeMatch = text.match(/\b(19\d0|20\d0)s\b/i);
+  if (decadeMatch) {
+    const start = Number.parseInt(decadeMatch[1], 10);
+    return { yearMin: start, yearMax: start + 9 };
+  }
+
+  return { yearMin: null, yearMax: null };
+};
+
 export const parseLibraryQuery = (input = '') => {
   const text = String(input || '').trim();
   if (!text) {
@@ -42,5 +89,52 @@ export const parseLibraryQuery = (input = '') => {
     maxRuntime: runtimeMatch ? Number.parseInt(runtimeMatch[1], 10) : null,
     mood: moodMatch?.[1] || null,
     searchText: strippedSearch,
+  };
+};
+
+export const parseOracleQueryConstraints = (input = '') => {
+  const text = String(input || '').trim();
+  const normalizedText = text.toLowerCase();
+  if (!normalizedText) {
+    return {
+      normalizedText: '',
+      yearMin: null,
+      yearMax: null,
+      watchStatus: null,
+      genreIds: [],
+      genreNames: [],
+      hasConstraints: false,
+      strippedPrompt: '',
+    };
+  }
+
+  const { yearMin, yearMax } = getYearBounds(normalizedText);
+  const statusMatch = STATUS_HINTS.find((hint) => hint.pattern.test(normalizedText));
+  const genreMatches = ORACLE_GENRE_HINTS.filter((hint) => hint.pattern.test(normalizedText));
+  const genreIds = [...new Set(genreMatches.map((item) => item.id))];
+  const genreNames = [...new Set(genreMatches.map((item) => item.name))];
+
+  const strippedPrompt = normalizedText
+    .replace(/\bbetween\s+(19\d{2}|20\d{2})\s+(?:and|to)\s+(19\d{2}|20\d{2})\b/gi, '')
+    .replace(/\b(?:pre[-\s]?|before|older than|after|post|since)\s*(19\d{2}|20\d{2})(?:s)?\b/gi, '')
+    .replace(/\b(19\d0|20\d0)s\b/gi, '')
+    .replace(/\b(unwatched|to-watch|want to watch|watchlist|watched|seen)\b/gi, '')
+    .replace(/\b(horror|thriller|comedy|drama|romance|romantic|science fiction|sci[- ]?fi|animation|animated|crime|documentary|fantasy|mystery|action)\b/gi, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  const hasConstraints = Boolean(
+    statusMatch?.status || Number.isFinite(yearMin) || Number.isFinite(yearMax) || genreIds.length > 0,
+  );
+
+  return {
+    normalizedText,
+    yearMin: Number.isFinite(yearMin) ? yearMin : null,
+    yearMax: Number.isFinite(yearMax) ? yearMax : null,
+    watchStatus: statusMatch?.status || null,
+    genreIds,
+    genreNames,
+    hasConstraints,
+    strippedPrompt,
   };
 };

--- a/src/utils/oracleAnalytics.js
+++ b/src/utils/oracleAnalytics.js
@@ -1,4 +1,5 @@
 import { getSupabase } from "../supabaseClient";
+import { getOracleFailureBucket } from "./oracleReliability";
 
 const ADMIN_EMAIL = "sonofloke@gmail.com";
 
@@ -27,6 +28,8 @@ export const classifyOracleError = (error) => {
   const tagged = raw.match(/\[oracle:([a-z]+)(?::(\d+))?\]/i);
   const taggedProvider = tagged?.[1] || provider || null;
   const taggedStatus = tagged?.[2] || status || null;
+  const failureBucket = getOracleFailureBucket(error);
+  const failureStage = taggedProvider || "orchestration";
   if (!raw) return { errorCode: null, fallbackReason: null };
 
   if (raw.includes("daily oracle limit")) {
@@ -35,6 +38,8 @@ export const classifyOracleError = (error) => {
       fallbackReason: "budget_limit",
       provider: taggedProvider,
       statusCode: taggedStatus,
+      failureBucket,
+      failureStage,
     };
   }
   if (raw.includes("openrouter")) {
@@ -44,6 +49,8 @@ export const classifyOracleError = (error) => {
       fallbackReason: "openrouter_unavailable",
       provider: taggedProvider || "openrouter",
       statusCode: taggedStatus,
+      failureBucket,
+      failureStage,
     };
   }
   if (raw.includes("tmdb")) {
@@ -52,6 +59,8 @@ export const classifyOracleError = (error) => {
       fallbackReason: "tmdb_unavailable",
       provider: taggedProvider || "tmdb",
       statusCode: taggedStatus,
+      failureBucket,
+      failureStage,
     };
   }
   if (raw.includes("gemini") || raw.includes("oracle is silent")) {
@@ -61,6 +70,8 @@ export const classifyOracleError = (error) => {
       fallbackReason: "gemini_unavailable",
       provider: taggedProvider || "gemini",
       statusCode: taggedStatus,
+      failureBucket,
+      failureStage,
     };
   }
   if (raw.includes("network") || raw.includes("fetch")) {
@@ -69,6 +80,8 @@ export const classifyOracleError = (error) => {
       fallbackReason: "network_error",
       provider: taggedProvider,
       statusCode: taggedStatus,
+      failureBucket,
+      failureStage,
     };
   }
 
@@ -77,6 +90,8 @@ export const classifyOracleError = (error) => {
     fallbackReason: null,
     provider: taggedProvider,
     statusCode: taggedStatus,
+    failureBucket,
+    failureStage,
   };
 };
 
@@ -86,6 +101,8 @@ export const buildOracleEventPayload = ({
   success,
   fallbackReason,
   errorCode,
+  failureBucket,
+  failureStage,
   errorMessage,
   budgetSource,
   requestSource,
@@ -107,6 +124,8 @@ export const buildOracleEventPayload = ({
     success: Boolean(success),
     fallback_reason: cleanText(fallbackReason || meta?.fallbackReason),
     error_code: cleanText(errorCode),
+    failure_bucket: cleanText(failureBucket),
+    failure_stage: cleanText(failureStage),
     error_message: cleanText(errorMessage),
     budget_source: cleanText(budgetSource),
     request_source: cleanText(requestSource),

--- a/src/utils/oracleAnalytics.js
+++ b/src/utils/oracleAnalytics.js
@@ -1,4 +1,3 @@
-import { getSupabase } from "../supabaseClient";
 import { getOracleFailureBucket } from "./oracleReliability";
 
 const ADMIN_EMAIL = "sonofloke@gmail.com";
@@ -6,6 +5,46 @@ const ADMIN_EMAIL = "sonofloke@gmail.com";
 const cleanText = (value) => {
   if (!value) return null;
   return String(value).trim().slice(0, 500) || null;
+};
+
+const parseOptionalNonNegativeInt = (value) => {
+  if (value == null || value === "") return null;
+  const parsed = Number.parseInt(String(value), 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return null;
+  return parsed;
+};
+
+const normalizeProviderAttempt = (attempt) => {
+  if (!attempt || typeof attempt !== "object") return null;
+  const latency = parseOptionalNonNegativeInt(attempt.latency_ms);
+  return {
+    provider: cleanText(attempt.provider),
+    model: cleanText(attempt.model),
+    result: cleanText(attempt.result),
+    status: cleanText(attempt.status),
+    failure_bucket: cleanText(attempt.failure_bucket),
+    latency_ms: latency,
+  };
+};
+
+const normalizeProviderAttempts = (attempts) => {
+  if (!Array.isArray(attempts)) return [];
+  return attempts
+    .map((attempt) => normalizeProviderAttempt(attempt))
+    .filter(Boolean);
+};
+
+const normalizeSelectedProviderIds = (providerIds) => {
+  if (!Array.isArray(providerIds)) return [];
+  const seen = new Set();
+  return providerIds
+    .map((value) => Number.parseInt(String(value), 10))
+    .filter((value) => Number.isFinite(value) && value > 0)
+    .filter((value) => {
+      if (seen.has(value)) return false;
+      seen.add(value);
+      return true;
+    });
 };
 
 export const parseLatencyMs = (latency) => {
@@ -109,11 +148,18 @@ export const buildOracleEventPayload = ({
   promptType,
   recommendationCount = 0,
   tmdbHitCount = 0,
+  selectedProviderIds = [],
 }) => {
   const safeRecommendations = Math.max(0, Number(recommendationCount) || 0);
   const safeHits = Math.max(0, Number(tmdbHitCount) || 0);
   const tmdbHitRate =
     safeRecommendations > 0 ? safeHits / safeRecommendations : 0;
+  const qualityMetrics = meta?.qualityMetrics || {};
+  const attemptMetrics = meta?.attemptMetrics || {};
+  const rankingMetrics = meta?.rankingMetrics || {};
+  const resolvedSelectedProviderIds = normalizeSelectedProviderIds(
+    selectedProviderIds.length > 0 ? selectedProviderIds : meta?.selectedProviderIds,
+  );
 
   return {
     user_id: userId,
@@ -133,11 +179,34 @@ export const buildOracleEventPayload = ({
     recommendation_count: safeRecommendations,
     tmdb_hit_count: safeHits,
     tmdb_hit_rate: Number(tmdbHitRate.toFixed(4)),
+    input_recommendation_count: parseOptionalNonNegativeInt(
+      qualityMetrics.inputRecommendationCount,
+    ),
+    post_filter_recommendation_count: parseOptionalNonNegativeInt(
+      qualityMetrics.postFilterRecommendationCount,
+    ),
+    dedupe_dropped_count: parseOptionalNonNegativeInt(
+      qualityMetrics.dedupeDroppedCount,
+    ),
+    rejected_violation_attempt_count: parseOptionalNonNegativeInt(
+      qualityMetrics.rejectedViolationAttemptCount,
+    ),
+    provider_attempt_count: parseOptionalNonNegativeInt(
+      attemptMetrics.providerAttemptCount,
+    ),
+    fallback_depth: parseOptionalNonNegativeInt(attemptMetrics.fallbackDepth),
+    provider_attempts: normalizeProviderAttempts(attemptMetrics.providerAttempts),
+    selected_provider_ids: resolvedSelectedProviderIds,
+    provider_match_count:
+      parseOptionalNonNegativeInt(rankingMetrics.matchedRecommendationCount) || 0,
+    provider_filtered_out_count:
+      parseOptionalNonNegativeInt(rankingMetrics.filteredOutCount) || 0,
   };
 };
 
 export const trackOracleProviderEvent = async (eventPayload) => {
   try {
+    const { getSupabase } = await import("../supabaseClient");
     const supabase = getSupabase();
     const { error } = await supabase
       .from("oracle_provider_events")

--- a/src/utils/oracleQueryConstraints.js
+++ b/src/utils/oracleQueryConstraints.js
@@ -1,0 +1,26 @@
+import { parseOracleQueryConstraints } from "./naturalLanguageSort";
+
+export const resolveOracleQueryConstraints = async (
+  prompt,
+  {
+    constraintsEnabled = false,
+    groqIntentEnabled = false,
+    groqIntentParser = null,
+  } = {}
+) => {
+  if (!constraintsEnabled) return null;
+  if (!groqIntentEnabled || typeof groqIntentParser !== "function") {
+    return parseOracleQueryConstraints(prompt);
+  }
+
+  try {
+    const parsedByGroq = await groqIntentParser(prompt);
+    if (parsedByGroq && typeof parsedByGroq === "object") {
+      return parsedByGroq;
+    }
+  } catch (_err) {
+    // Fail-soft to deterministic parser.
+  }
+
+  return parseOracleQueryConstraints(prompt);
+};

--- a/src/utils/oracleRanking.js
+++ b/src/utils/oracleRanking.js
@@ -1,0 +1,95 @@
+const toNonNegativeNumber = (value) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+};
+
+export const rankRecommendationsByProviderAffinity = ({
+  recommendations = [],
+  tmdbResults = [],
+  providerResults = [],
+  selectedProviderIds = [],
+}) => {
+  const hasProviderPreferences = Array.isArray(selectedProviderIds) && selectedProviderIds.length > 0;
+  const totalRecommendations = Math.min(
+    recommendations.length,
+    tmdbResults.length,
+    providerResults.length,
+  );
+
+  if (!hasProviderPreferences || totalRecommendations === 0) {
+    return {
+      recommendations,
+      tmdbResults,
+      providerResults,
+      rankingMetrics: {
+        hasProviderPreferences,
+        totalRecommendations,
+        matchedRecommendationCount: 0,
+        unmatchedRecommendationCount: totalRecommendations,
+        filteredOutCount: 0,
+        reorderedCount: 0,
+        promotedFirstItem: false,
+      },
+    };
+  }
+
+  const combined = recommendations.map((rec, index) => {
+    const tmdb = tmdbResults[index] || null;
+    const providers = providerResults[index] || null;
+    const providerLogos = Array.isArray(tmdb?.provider_logos) ? tmdb.provider_logos : [];
+    const providerMatchScore = providerLogos.length;
+    const hasProviderMatch = providerMatchScore > 0;
+    return {
+      index,
+      rec,
+      tmdb,
+      providers,
+      hasProviderMatch,
+      providerMatchScore,
+      voteAverage: toNonNegativeNumber(tmdb?.vote_average),
+      voteCount: toNonNegativeNumber(tmdb?.vote_count),
+    };
+  });
+
+  const originalFirstIndex = combined[0]?.index ?? -1;
+  const sorted = [...combined].sort((a, b) => {
+    if (Number(b.hasProviderMatch) !== Number(a.hasProviderMatch)) {
+      return Number(b.hasProviderMatch) - Number(a.hasProviderMatch);
+    }
+    if (b.providerMatchScore !== a.providerMatchScore) {
+      return b.providerMatchScore - a.providerMatchScore;
+    }
+    if (b.voteAverage !== a.voteAverage) {
+      return b.voteAverage - a.voteAverage;
+    }
+    if (b.voteCount !== a.voteCount) {
+      return b.voteCount - a.voteCount;
+    }
+    return a.index - b.index;
+  });
+
+  const reorderedCount = sorted.reduce(
+    (count, item, idx) => (item.index !== idx ? count + 1 : count),
+    0,
+  );
+  const matchedRecommendationCount = sorted.filter((item) => item.hasProviderMatch).length;
+  const unmatchedRecommendationCount = Math.max(0, sorted.length - matchedRecommendationCount);
+  const filteredOutCount = unmatchedRecommendationCount;
+
+  return {
+    recommendations: sorted.map((item) => item.rec),
+    tmdbResults: sorted.map((item) => item.tmdb),
+    providerResults: sorted.map((item) => item.providers),
+    rankingMetrics: {
+      hasProviderPreferences,
+      totalRecommendations: sorted.length,
+      matchedRecommendationCount,
+      unmatchedRecommendationCount,
+      filteredOutCount,
+      reorderedCount,
+      promotedFirstItem:
+        matchedRecommendationCount > 0 && sorted[0]?.index !== originalFirstIndex,
+    },
+  };
+};
+

--- a/src/utils/oracleReliability.js
+++ b/src/utils/oracleReliability.js
@@ -1,0 +1,64 @@
+const FALLBACK_RATIONALE =
+  "Fallback recommendation based on your vibe and available metadata.";
+const FALLBACK_VIBE_CHECK = "Fallback pick for your vibe";
+
+export const ORACLE_PROVIDER_TIMEOUT_MS = {
+  gemini: 9000,
+  openrouter: 9000,
+  tmdb: 6000,
+};
+
+export const ORACLE_PROVIDER_MAX_RETRIES = {
+  gemini: 2,
+  openrouter: 1,
+  tmdb: 1,
+};
+
+export const isAbortLikeError = (error) => {
+  const raw = String(error?.message || "").toLowerCase();
+  return Boolean(
+    error?.name === "AbortError" ||
+      error?.isAbort ||
+      raw.includes("aborted") ||
+      raw.includes("cancelled"),
+  );
+};
+
+export const getOracleFailureBucket = (error) => {
+  const raw = String(error?.message || "").toLowerCase();
+  const status = Number(error?.status || error?.statusCode || 0);
+  if (isAbortLikeError(error) || raw.includes("timeout")) return "timeout";
+  if (status === 429 || raw.includes("rate limit")) return "rate_limit";
+  if (raw.includes("parse") || raw.includes("json") || status === 422) return "parse_fail";
+  if (
+    status === 500 ||
+    status === 503 ||
+    status === 502 ||
+    raw.includes("network") ||
+    raw.includes("fetch") ||
+    raw.includes("unavailable")
+  ) {
+    return "upstream_unavailable";
+  }
+  return "unknown";
+};
+
+export const shouldRetryOracleError = (error) => {
+  if (isAbortLikeError(error)) return false;
+  const status = Number(error?.status || error?.statusCode || 0);
+  if (status === 404) return false;
+  return status === 429 || status === 500 || status === 503 || getOracleFailureBucket(error) === "timeout";
+};
+
+export const ensureOracleRecommendationShape = (recommendations = []) =>
+  (recommendations || [])
+    .filter(Boolean)
+    .map((rec) => ({
+      ...rec,
+      title: String(rec?.title || "").trim(),
+      year: Number.isFinite(Number(rec?.year)) ? Number(rec.year) : null,
+      rationale: String(rec?.rationale || "").trim() || FALLBACK_RATIONALE,
+      vibeCheck: String(rec?.vibeCheck || "").trim() || FALLBACK_VIBE_CHECK,
+    }))
+    .filter((rec) => rec.title.length > 0);
+

--- a/src/utils/oracleTasteProfile.js
+++ b/src/utils/oracleTasteProfile.js
@@ -1,0 +1,200 @@
+export const LOW_RATING_THRESHOLD = 2.5;
+export const RECENT_WINDOW_DAYS = 45;
+export const RECENCY_WEIGHT_SCALE = 0.35;
+export const WEIGHTED_SECTION_LIMITS = {
+  lovedTitles: 18,
+  avoidTitles: 10,
+  topMoods: 6,
+  topGenres: 6,
+  recentWatched: 8,
+  recentToWatch: 8,
+  curatedTitles: 16,
+};
+
+const normalizeTitle = (value) => String(value || "").trim().toLowerCase();
+
+const pickTopEntries = (counterMap, limit = 5) =>
+  [...counterMap.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([label]) => label);
+
+const parseYearBucket = (yearValue) => {
+  const year = Number.parseInt(String(yearValue || ""), 10);
+  if (!Number.isFinite(year)) return null;
+  return `${Math.floor(year / 10) * 10}s`;
+};
+
+const parseDateSafe = (value) => {
+  const parsed = Date.parse(String(value || ""));
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+
+const computeRecencyWeight = (createdAt) => {
+  const parsedAt = parseDateSafe(createdAt);
+  if (!parsedAt) return 0;
+  const ageMs = Date.now() - parsedAt;
+  const ageDays = ageMs / (1000 * 60 * 60 * 24);
+  if (ageDays <= 0) return 1;
+  const ratio = clamp(1 - ageDays / RECENT_WINDOW_DAYS, 0, 1);
+  return Number((ratio * RECENCY_WEIGHT_SCALE).toFixed(3));
+};
+
+const pickTopWeightedEntries = (counterMap, limit = 5) =>
+  [...counterMap.entries()]
+    .sort((a, b) => b[1].score - a[1].score || b[1].count - a[1].count || a[0].localeCompare(b[0]))
+    .slice(0, limit)
+    .map(([label, stats]) => ({
+      label,
+      score: Number(stats.score.toFixed(3)),
+      count: stats.count,
+    }));
+
+const pickRecentTitles = (entries = [], limit = 8) =>
+  entries
+    .filter((entry) => entry?.title)
+    .sort((a, b) => (parseDateSafe(b.created_at) || 0) - (parseDateSafe(a.created_at) || 0))
+    .slice(0, limit)
+    .map((entry) => entry.title);
+
+export const buildUserTasteProfile = (logs = [], recentToWatch = [], listItems = []) => {
+  const watched = logs.filter((entry) => entry.watch_status === "watched");
+  const highlyRated = watched.filter((entry) => Number(entry.rating || 0) >= 4);
+  const lowRated = watched.filter(
+    (entry) => Number(entry.rating || 0) > 0 && Number(entry.rating || 0) <= LOW_RATING_THRESHOLD
+  );
+  const recentWindowIso = new Date(Date.now() - 1000 * 60 * 60 * 24 * RECENT_WINDOW_DAYS).toISOString();
+  const recentWatched = watched.filter((entry) => entry.created_at && entry.created_at >= recentWindowIso);
+
+  const moodScores = new Map();
+  const genreScores = new Map();
+  const decadeCounts = new Map();
+  const positiveTitles = [];
+  const avoidTitles = [];
+  const neutralTitles = [];
+
+  for (const entry of logs) {
+    const normalized = normalizeTitle(entry.title);
+    if (!normalized) continue;
+
+    const rating = Number(entry.rating || 0);
+    if (entry.watch_status === "watched" && rating >= 4 && positiveTitles.length < 25) {
+      positiveTitles.push(entry.title);
+    }
+    if (entry.watch_status === "watched" && rating > 0 && rating <= LOW_RATING_THRESHOLD && avoidTitles.length < 16) {
+      avoidTitles.push(entry.title);
+    }
+    if (entry.watch_status === "watched" && rating > LOW_RATING_THRESHOLD && rating < 4 && neutralTitles.length < 20) {
+      neutralTitles.push(entry.title);
+    }
+
+    const recencyWeight = computeRecencyWeight(entry.created_at);
+    const ratingLift = rating >= 4 ? 0.25 : 0;
+    if (Array.isArray(entry.moods)) {
+      entry.moods.forEach((mood) => {
+        const normalizedMood = normalizeTitle(mood);
+        if (!normalizedMood) return;
+        const previous = moodScores.get(normalizedMood) || { score: 0, count: 0 };
+        moodScores.set(normalizedMood, {
+          score: previous.score + 1 + recencyWeight,
+          count: previous.count + 1,
+        });
+      });
+    }
+    if (Array.isArray(entry.genres)) {
+      entry.genres.forEach((genre) => {
+        const normalizedGenre = normalizeTitle(genre);
+        if (!normalizedGenre) return;
+        const previous = genreScores.get(normalizedGenre) || { score: 0, count: 0 };
+        genreScores.set(normalizedGenre, {
+          score: previous.score + 1 + recencyWeight + ratingLift,
+          count: previous.count + 1,
+        });
+      });
+    }
+
+    const decade = parseYearBucket(entry.year);
+    if (decade) {
+      decadeCounts.set(decade, (decadeCounts.get(decade) || 0) + 1);
+    }
+  }
+
+  const recentToWatchTitles = recentToWatch.map((entry) => entry.title).filter(Boolean).slice(0, 8);
+  const curatedTitles = listItems.map((entry) => entry.title).filter(Boolean).slice(0, 20);
+
+  const topMoods = pickTopWeightedEntries(moodScores, WEIGHTED_SECTION_LIMITS.topMoods);
+  const topGenres = pickTopWeightedEntries(genreScores, WEIGHTED_SECTION_LIMITS.topGenres);
+  const topDecades = pickTopEntries(decadeCounts, 3);
+  const avgRating =
+    watched.length > 0
+      ? (
+          watched.reduce((sum, item) => sum + Number(item.rating || 0), 0) /
+          Math.max(watched.filter((item) => Number(item.rating || 0) > 0).length, 1)
+        ).toFixed(2)
+      : null;
+
+  return {
+    summary: {
+      watchedCount: watched.length,
+      recentWatchedCount: recentWatched.length,
+      highRatedCount: highlyRated.length,
+      lowRatedCount: lowRated.length,
+      lowRatingThreshold: LOW_RATING_THRESHOLD,
+      avgRating,
+      topMoods: topMoods.map((entry) => entry.label),
+      topGenres: topGenres.map((entry) => entry.label),
+      topDecades,
+    },
+    weightedSignals: {
+      moods: topMoods,
+      genres: topGenres,
+    },
+    ratingBuckets: {
+      liked: [...new Set(positiveTitles)].slice(0, WEIGHTED_SECTION_LIMITS.lovedTitles),
+      neutral: [...new Set(neutralTitles)].slice(0, 8),
+      avoid: [...new Set(avoidTitles)].slice(0, WEIGHTED_SECTION_LIMITS.avoidTitles),
+    },
+    positiveTitles: [...new Set(positiveTitles)].slice(0, WEIGHTED_SECTION_LIMITS.lovedTitles),
+    avoidTitles: [...new Set(avoidTitles)].slice(0, WEIGHTED_SECTION_LIMITS.avoidTitles),
+    recentWatchedTitles: [...new Set(pickRecentTitles(recentWatched, WEIGHTED_SECTION_LIMITS.recentWatched))],
+    recentToWatchTitles: [...new Set(recentToWatchTitles)],
+    curatedTitles: [...new Set(curatedTitles)],
+  };
+};
+
+export const buildTasteContextString = (profile) => {
+  const summary = profile?.summary || {};
+  const weightedSignals = profile?.weightedSignals || {};
+  const moodSignalLine =
+    (weightedSignals.moods || [])
+      .map((entry) => `${entry.label}(${entry.score.toFixed(2)})`)
+      .join(", ") || "none";
+  const genreSignalLine =
+    (weightedSignals.genres || [])
+      .map((entry) => `${entry.label}(${entry.score.toFixed(2)})`)
+      .join(", ") || "none";
+  const likedTitles = (profile?.ratingBuckets?.liked || []).slice(0, WEIGHTED_SECTION_LIMITS.lovedTitles);
+  const avoidTitles = (profile?.ratingBuckets?.avoid || []).slice(0, WEIGHTED_SECTION_LIMITS.avoidTitles);
+  const neutralTitles = (profile?.ratingBuckets?.neutral || []).slice(0, 8);
+  const recentWatchedTitles = (profile?.recentWatchedTitles || []).slice(0, WEIGHTED_SECTION_LIMITS.recentWatched);
+  const recentToWatchTitles = (profile?.recentToWatchTitles || []).slice(0, WEIGHTED_SECTION_LIMITS.recentToWatch);
+  const curatedTitles = (profile?.curatedTitles || []).slice(0, WEIGHTED_SECTION_LIMITS.curatedTitles);
+
+  const lines = [
+    `TasteStats: watched=${summary.watchedCount || 0}, recent45d=${summary.recentWatchedCount || 0}, avgRating=${summary.avgRating || "N/A"}`,
+    `TopMoods: ${(summary.topMoods || []).slice(0, WEIGHTED_SECTION_LIMITS.topMoods).join(", ") || "none"}`,
+    `TopGenres: ${(summary.topGenres || []).slice(0, WEIGHTED_SECTION_LIMITS.topGenres).join(", ") || "none"}`,
+    `MoodAffinityWeighted: ${moodSignalLine}`,
+    `GenreAffinityWeighted: ${genreSignalLine}`,
+    `PreferredDecades: ${(summary.topDecades || []).join(", ") || "none"}`,
+    `LovedTitles: ${likedTitles.join(", ") || "none"}`,
+    `AvoidSimilarTo: ${avoidTitles.join(", ") || "none"}`,
+    `NeutralTitles: ${neutralTitles.join(", ") || "none"}`,
+    `RecentWatched: ${recentWatchedTitles.join(", ") || "none"}`,
+    `RecentToWatch: ${recentToWatchTitles.join(", ") || "none"}`,
+    `CuratedLists: ${curatedTitles.join(", ") || "none"}`,
+  ];
+  return lines.join("\n");
+};

--- a/src/utils/yearInReview.js
+++ b/src/utils/yearInReview.js
@@ -1,0 +1,161 @@
+/**
+ * Year in Review — pure aggregation helpers (Phase 6.8 MVP).
+ * See artifacts/adr-year-in-review.md for canonical date and metric rules.
+ */
+
+const MONTH_SHORT = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
+
+/**
+ * @param {Record<string, unknown>} log
+ * @returns {Date | null}
+ */
+export function canonicalWatchDate(log) {
+  if (!log) return null;
+  const raw = log.watched_at ?? log.created_at;
+  if (raw == null || raw === '') return null;
+  const d = new Date(raw);
+  return Number.isFinite(d.getTime()) ? d : null;
+}
+
+/**
+ * @param {Record<string, unknown>} log
+ * @returns {boolean}
+ */
+export function isWatchedLog(log) {
+  return String(log?.watch_status || '').toLowerCase() === 'watched';
+}
+
+/**
+ * @param {Record<string, unknown>[]} logs
+ * @param {number} year calendar year (e.g. 2026)
+ * @returns {Record<string, unknown>[]}
+ */
+export function filterLogsForYear(logs, year) {
+  if (!Array.isArray(logs) || !Number.isFinite(year)) return [];
+  return logs.filter((log) => {
+    if (!isWatchedLog(log)) return false;
+    const d = canonicalWatchDate(log);
+    if (!d) return false;
+    return d.getFullYear() === year;
+  });
+}
+
+function topNamedCounts(countMap, limit) {
+  return Object.entries(countMap)
+    .filter(([, n]) => n > 0)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([name, count]) => ({ name, count }));
+}
+
+/**
+ * @param {Record<string, unknown>[]} logs full movie_logs rows for one user
+ * @param {number} year
+ * @returns {{
+ *   year: number,
+ *   filmCount: number,
+ *   avgRating: number | null,
+ *   ratingHistogram: { rating: string, count: number }[],
+ *   topGenres: { name: string, count: number }[],
+ *   topMoods: { name: string, count: number }[],
+ *   monthlyCounts: { monthIndex: number, label: string, count: number }[],
+ *   physicalScanCount: number,
+ *   reviewsWrittenCount: number,
+ *   ratedFilmCount: number,
+ * }}
+ */
+export function buildYearInReview(year, logs) {
+  const yearLogs = filterLogsForYear(logs, year);
+
+  const ratedLogs = yearLogs.filter((m) => {
+    const r = m?.rating;
+    return r != null && Number.isFinite(Number(r));
+  });
+
+  let avgRating = null;
+  if (ratedLogs.length > 0) {
+    const sum = ratedLogs.reduce((acc, m) => acc + Number(m.rating), 0);
+    avgRating = Math.round((sum / ratedLogs.length) * 10) / 10;
+  }
+
+  const ratingCounts = {};
+  ratedLogs.forEach((movie) => {
+    const key = Number(movie.rating).toFixed(1);
+    ratingCounts[key] = (ratingCounts[key] || 0) + 1;
+  });
+
+  const ratingHistogram = Object.entries(ratingCounts)
+    .map(([rating, count]) => ({ rating, count }))
+    .sort((a, b) => parseFloat(b.rating) - parseFloat(a.rating));
+
+  const genreCounts = {};
+  yearLogs.forEach((movie) => {
+    const genres = movie.genres;
+    if (!Array.isArray(genres)) return;
+    genres.forEach((g) => {
+      const label = String(g || '').trim();
+      if (!label) return;
+      genreCounts[label] = (genreCounts[label] || 0) + 1;
+    });
+  });
+
+  const moodCounts = {};
+  yearLogs.forEach((movie) => {
+    const moods = movie.moods;
+    if (!Array.isArray(moods)) return;
+    moods.forEach((mood) => {
+      const id = String(mood || '').trim();
+      if (!id) return;
+      moodCounts[id] = (moodCounts[id] || 0) + 1;
+    });
+  });
+
+  const monthly = Array.from({ length: 12 }, (_, i) => ({
+    monthIndex: i,
+    label: MONTH_SHORT[i],
+    count: 0,
+  }));
+
+  yearLogs.forEach((log) => {
+    const d = canonicalWatchDate(log);
+    if (!d) return;
+    const idx = d.getMonth();
+    if (idx >= 0 && idx < 12) monthly[idx].count += 1;
+  });
+
+  const physicalScanCount = yearLogs.filter((m) => {
+    const upc = m?.source_upc;
+    return upc != null && String(upc).trim() !== '';
+  }).length;
+
+  const reviewsWrittenCount = yearLogs.filter((m) => {
+    const rev = m?.review;
+    return typeof rev === 'string' && rev.trim().length > 0;
+  }).length;
+
+  return {
+    year,
+    filmCount: yearLogs.length,
+    avgRating,
+    ratingHistogram,
+    topGenres: topNamedCounts(genreCounts, 5),
+    topMoods: topNamedCounts(moodCounts, 12),
+    monthlyCounts: monthly,
+    physicalScanCount,
+    reviewsWrittenCount,
+    ratedFilmCount: ratedLogs.length,
+  };
+}

--- a/supabase/migrations/20260430000500_oracle_taste_profile_rpc.sql
+++ b/supabase/migrations/20260430000500_oracle_taste_profile_rpc.sql
@@ -1,0 +1,269 @@
+-- Oracle taste-profile aggregation RPC
+-- Moves expensive weighting/capping work into Postgres for deterministic, low-latency context hydration.
+
+CREATE OR REPLACE FUNCTION public.get_oracle_taste_profile(p_user_id UUID)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+  v_is_authorized BOOLEAN := auth.uid() = p_user_id;
+  v_recent_window_days INT := 45;
+  v_low_rating_threshold NUMERIC := 2.5;
+  v_recency_weight_scale NUMERIC := 0.35;
+  v_loved_limit INT := 18;
+  v_avoid_limit INT := 10;
+  v_top_mood_limit INT := 6;
+  v_top_genre_limit INT := 6;
+  v_recent_watched_limit INT := 8;
+  v_recent_to_watch_limit INT := 8;
+  v_curated_limit INT := 16;
+  v_profile JSONB;
+BEGIN
+  IF NOT v_is_authorized THEN
+    RAISE EXCEPTION 'Not authorized to read Oracle taste profile for this user';
+  END IF;
+
+  WITH logs AS (
+    SELECT
+      title,
+      watch_status,
+      rating,
+      moods,
+      genres,
+      year,
+      created_at
+    FROM public.movie_logs
+    WHERE user_id = p_user_id
+  ),
+  watched AS (
+    SELECT * FROM logs WHERE watch_status = 'watched'
+  ),
+  recent_to_watch AS (
+    SELECT title, created_at
+    FROM public.movie_logs
+    WHERE user_id = p_user_id
+      AND watch_status = 'to-watch'
+    ORDER BY created_at DESC
+    LIMIT v_recent_to_watch_limit
+  ),
+  curated AS (
+    SELECT li.title
+    FROM public.list_items li
+    JOIN public.lists l ON l.id = li.list_id
+    WHERE l.user_id = p_user_id
+      AND li.title IS NOT NULL
+  ),
+  watched_stats AS (
+    SELECT
+      COUNT(*)::INT AS watched_count,
+      COUNT(*) FILTER (WHERE created_at >= timezone('utc', now()) - make_interval(days => v_recent_window_days))::INT AS recent_watched_count,
+      COUNT(*) FILTER (WHERE COALESCE(rating, 0) >= 4)::INT AS high_rated_count,
+      COUNT(*) FILTER (WHERE COALESCE(rating, 0) > 0 AND COALESCE(rating, 0) <= v_low_rating_threshold)::INT AS low_rated_count,
+      CASE
+        WHEN COUNT(*) FILTER (WHERE COALESCE(rating, 0) > 0) > 0
+          THEN TO_CHAR(
+            (SUM(COALESCE(rating, 0)) / NULLIF(COUNT(*) FILTER (WHERE COALESCE(rating, 0) > 0), 0))::NUMERIC,
+            'FM999990.00'
+          )
+        ELSE NULL
+      END AS avg_rating
+    FROM watched
+  ),
+  mood_scores AS (
+    SELECT
+      LOWER(TRIM(mood.value)) AS label,
+      COUNT(*)::INT AS count,
+      SUM(
+        1 + (
+          GREATEST(
+            0,
+            LEAST(
+              1,
+              1 - (EXTRACT(EPOCH FROM (timezone('utc', now()) - COALESCE(w.created_at, timezone('utc', now())))) / 86400.0) / v_recent_window_days
+            )
+          ) * v_recency_weight_scale
+        )
+      )::NUMERIC AS score
+    FROM watched w
+    CROSS JOIN LATERAL unnest(COALESCE(w.moods, ARRAY[]::text[])) AS mood(value)
+    WHERE TRIM(COALESCE(mood.value, '')) <> ''
+    GROUP BY LOWER(TRIM(mood.value))
+  ),
+  top_moods AS (
+    SELECT
+      label,
+      ROUND(score::NUMERIC, 3) AS score,
+      count
+    FROM mood_scores
+    ORDER BY score DESC, count DESC, label ASC
+    LIMIT v_top_mood_limit
+  ),
+  genre_scores AS (
+    SELECT
+      LOWER(TRIM(genre.value)) AS label,
+      COUNT(*)::INT AS count,
+      SUM(
+        1 + (
+          GREATEST(
+            0,
+            LEAST(
+              1,
+              1 - (EXTRACT(EPOCH FROM (timezone('utc', now()) - COALESCE(w.created_at, timezone('utc', now())))) / 86400.0) / v_recent_window_days
+            )
+          ) * v_recency_weight_scale
+        ) +
+        CASE WHEN COALESCE(w.rating, 0) >= 4 THEN 0.25 ELSE 0 END
+      )::NUMERIC AS score
+    FROM watched w
+    CROSS JOIN LATERAL unnest(COALESCE(w.genres, ARRAY[]::text[])) AS genre(value)
+    WHERE TRIM(COALESCE(genre.value, '')) <> ''
+    GROUP BY LOWER(TRIM(genre.value))
+  ),
+  top_genres AS (
+    SELECT
+      label,
+      ROUND(score::NUMERIC, 3) AS score,
+      count
+    FROM genre_scores
+    ORDER BY score DESC, count DESC, label ASC
+    LIMIT v_top_genre_limit
+  ),
+  top_decades AS (
+    SELECT
+      CONCAT((FLOOR(year::NUMERIC / 10) * 10)::INT, 's') AS decade,
+      COUNT(*)::INT AS count
+    FROM logs
+    WHERE year IS NOT NULL
+    GROUP BY CONCAT((FLOOR(year::NUMERIC / 10) * 10)::INT, 's')
+    ORDER BY count DESC, decade ASC
+    LIMIT 3
+  ),
+  liked_titles AS (
+    SELECT DISTINCT title
+    FROM watched
+    WHERE COALESCE(rating, 0) >= 4
+      AND title IS NOT NULL
+      AND TRIM(title) <> ''
+    ORDER BY title ASC
+    LIMIT v_loved_limit
+  ),
+  neutral_titles AS (
+    SELECT DISTINCT title
+    FROM watched
+    WHERE COALESCE(rating, 0) > v_low_rating_threshold
+      AND COALESCE(rating, 0) < 4
+      AND title IS NOT NULL
+      AND TRIM(title) <> ''
+    ORDER BY title ASC
+    LIMIT 8
+  ),
+  avoid_titles AS (
+    SELECT DISTINCT title
+    FROM watched
+    WHERE COALESCE(rating, 0) > 0
+      AND COALESCE(rating, 0) <= v_low_rating_threshold
+      AND title IS NOT NULL
+      AND TRIM(title) <> ''
+    ORDER BY title ASC
+    LIMIT v_avoid_limit
+  ),
+  recent_watched AS (
+    SELECT DISTINCT title, created_at
+    FROM watched
+    WHERE title IS NOT NULL
+      AND TRIM(title) <> ''
+    ORDER BY created_at DESC
+    LIMIT v_recent_watched_limit
+  ),
+  context_lines AS (
+    SELECT ARRAY_REMOVE(
+      ARRAY[
+        CONCAT(
+          'TasteStats: watched=', COALESCE((SELECT watched_count::TEXT FROM watched_stats), '0'),
+          ', recent45d=', COALESCE((SELECT recent_watched_count::TEXT FROM watched_stats), '0'),
+          ', avgRating=', COALESCE((SELECT avg_rating FROM watched_stats), 'N/A')
+        ),
+        CONCAT('TopMoods: ', COALESCE((SELECT string_agg(label, ', ') FROM top_moods), 'none')),
+        CONCAT('TopGenres: ', COALESCE((SELECT string_agg(label, ', ') FROM top_genres), 'none')),
+        CONCAT(
+          'MoodAffinityWeighted: ',
+          COALESCE((SELECT string_agg(CONCAT(label, '(', TO_CHAR(score, 'FM999990.00'), ')'), ', ') FROM top_moods), 'none')
+        ),
+        CONCAT(
+          'GenreAffinityWeighted: ',
+          COALESCE((SELECT string_agg(CONCAT(label, '(', TO_CHAR(score, 'FM999990.00'), ')'), ', ') FROM top_genres), 'none')
+        ),
+        CONCAT('PreferredDecades: ', COALESCE((SELECT string_agg(decade, ', ') FROM top_decades), 'none')),
+        CONCAT('LovedTitles: ', COALESCE((SELECT string_agg(title, ', ') FROM liked_titles), 'none')),
+        CONCAT('AvoidSimilarTo: ', COALESCE((SELECT string_agg(title, ', ') FROM avoid_titles), 'none')),
+        CONCAT('NeutralTitles: ', COALESCE((SELECT string_agg(title, ', ') FROM neutral_titles), 'none')),
+        CONCAT('RecentWatched: ', COALESCE((SELECT string_agg(title, ', ') FROM recent_watched), 'none')),
+        CONCAT('RecentToWatch: ', COALESCE((SELECT string_agg(title, ', ') FROM recent_to_watch), 'none')),
+        CONCAT(
+          'CuratedLists: ',
+          COALESCE(
+            (
+              SELECT string_agg(title, ', ')
+              FROM (
+                SELECT DISTINCT title
+                FROM curated
+                ORDER BY title ASC
+                LIMIT v_curated_limit
+              ) ranked_curated
+            ),
+            'none'
+          )
+        )
+      ],
+      NULL
+    ) AS lines
+  )
+  SELECT jsonb_build_object(
+    'summary', jsonb_build_object(
+      'watchedCount', COALESCE((SELECT watched_count FROM watched_stats), 0),
+      'recentWatchedCount', COALESCE((SELECT recent_watched_count FROM watched_stats), 0),
+      'highRatedCount', COALESCE((SELECT high_rated_count FROM watched_stats), 0),
+      'lowRatedCount', COALESCE((SELECT low_rated_count FROM watched_stats), 0),
+      'lowRatingThreshold', v_low_rating_threshold,
+      'avgRating', COALESCE((SELECT avg_rating FROM watched_stats), NULL),
+      'topMoods', COALESCE((SELECT jsonb_agg(label) FROM top_moods), '[]'::JSONB),
+      'topGenres', COALESCE((SELECT jsonb_agg(label) FROM top_genres), '[]'::JSONB),
+      'topDecades', COALESCE((SELECT jsonb_agg(decade) FROM top_decades), '[]'::JSONB)
+    ),
+    'weightedSignals', jsonb_build_object(
+      'moods', COALESCE((SELECT jsonb_agg(jsonb_build_object('label', label, 'score', score, 'count', count)) FROM top_moods), '[]'::JSONB),
+      'genres', COALESCE((SELECT jsonb_agg(jsonb_build_object('label', label, 'score', score, 'count', count)) FROM top_genres), '[]'::JSONB)
+    ),
+    'ratingBuckets', jsonb_build_object(
+      'liked', COALESCE((SELECT jsonb_agg(title) FROM liked_titles), '[]'::JSONB),
+      'neutral', COALESCE((SELECT jsonb_agg(title) FROM neutral_titles), '[]'::JSONB),
+      'avoid', COALESCE((SELECT jsonb_agg(title) FROM avoid_titles), '[]'::JSONB)
+    ),
+    'positiveTitles', COALESCE((SELECT jsonb_agg(title) FROM liked_titles), '[]'::JSONB),
+    'avoidTitles', COALESCE((SELECT jsonb_agg(title) FROM avoid_titles), '[]'::JSONB),
+    'recentWatchedTitles', COALESCE((SELECT jsonb_agg(title) FROM recent_watched), '[]'::JSONB),
+    'recentToWatchTitles', COALESCE((SELECT jsonb_agg(title) FROM recent_to_watch), '[]'::JSONB),
+    'curatedTitles', COALESCE(
+      (
+        SELECT jsonb_agg(title)
+        FROM (
+          SELECT DISTINCT title
+          FROM curated
+          ORDER BY title ASC
+          LIMIT v_curated_limit
+        ) ranked_curated
+      ),
+      '[]'::JSONB
+    ),
+    'contextString', (
+      SELECT array_to_string(lines, E'\n')
+      FROM context_lines
+    )
+  ) INTO v_profile;
+
+  RETURN COALESCE(v_profile, '{}'::JSONB);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_oracle_taste_profile(UUID) TO authenticated;

--- a/supabase/migrations/20260430011000_oracle_provider_hybrid_metrics.sql
+++ b/supabase/migrations/20260430011000_oracle_provider_hybrid_metrics.sql
@@ -1,0 +1,8 @@
+alter table public.oracle_provider_events
+  add column if not exists input_recommendation_count integer,
+  add column if not exists post_filter_recommendation_count integer,
+  add column if not exists dedupe_dropped_count integer,
+  add column if not exists rejected_violation_attempt_count integer,
+  add column if not exists provider_attempt_count integer,
+  add column if not exists fallback_depth integer,
+  add column if not exists provider_attempts jsonb not null default '[]'::jsonb;

--- a/supabase/migrations/20260430113000_oracle_provider_failure_buckets.sql
+++ b/supabase/migrations/20260430113000_oracle_provider_failure_buckets.sql
@@ -1,0 +1,3 @@
+alter table public.oracle_provider_events
+  add column if not exists failure_bucket text,
+  add column if not exists failure_stage text;

--- a/supabase/migrations/20260507120000_movie_logs_watched_at.sql
+++ b/supabase/migrations/20260507120000_movie_logs_watched_at.sql
@@ -1,0 +1,7 @@
+-- Optional watch date for calendar / Year in Review (hybrid with created_at in app).
+-- Apply to remote DB with: supabase db push / migration run.
+ALTER TABLE public.movie_logs
+  ADD COLUMN IF NOT EXISTS watched_at TIMESTAMPTZ NULL;
+
+COMMENT ON COLUMN public.movie_logs.watched_at IS
+  'When the user watched the film; aggregates fall back to created_at when null.';

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -1,14 +1,22 @@
 import { test, expect } from '@playwright/test';
 
-const EMAIL = process.env.TEST_EMAIL!;
-const PASSWORD = process.env.TEST_PASSWORD!;
+const EMAIL = process.env.TEST_USER_EMAIL || process.env.TEST_EMAIL;
+const PASSWORD = process.env.TEST_USER_PASSWORD || process.env.TEST_PASSWORD;
+
+test.beforeEach(() => {
+  if (!EMAIL || !PASSWORD) {
+    throw new Error(
+      'Set TEST_USER_EMAIL and TEST_USER_PASSWORD (or TEST_EMAIL / TEST_PASSWORD) in .env',
+    );
+  }
+});
 
 test('login redirects to profile and shows username', async ({ page }) => {
   await page.goto('/login');
 
-  await page.getByPlaceholder(/email/i).fill(EMAIL);
-  await page.getByPlaceholder(/password/i).fill(PASSWORD);
-  await page.getByRole('button', { name: /login|sign in/i }).click();
+  await page.getByLabel(/^email$/i).fill(EMAIL);
+  await page.getByLabel(/^password$/i).fill(PASSWORD);
+  await page.getByRole('button', { name: /sign in/i }).click();
 
   await expect(page).toHaveURL(/\/profile/);
   await expect(page.getByRole('navigation')).toBeVisible();
@@ -16,11 +24,11 @@ test('login redirects to profile and shows username', async ({ page }) => {
 
 test('logout returns to login page', async ({ page }) => {
   await page.goto('/login');
-  await page.getByPlaceholder(/email/i).fill(EMAIL);
-  await page.getByPlaceholder(/password/i).fill(PASSWORD);
-  await page.getByRole('button', { name: /login|sign in/i }).click();
+  await page.getByLabel(/^email$/i).fill(EMAIL);
+  await page.getByLabel(/^password$/i).fill(PASSWORD);
+  await page.getByRole('button', { name: /sign in/i }).click();
   await expect(page).toHaveURL(/\/profile/);
 
-  await page.getByRole('button', { name: /logout/i }).click();
+  await page.getByRole('banner').getByRole('button', { name: /logout/i }).click();
   await expect(page).toHaveURL(/\/login|^\//);
 });

--- a/tests/oracle-query-intelligence.spec.ts
+++ b/tests/oracle-query-intelligence.spec.ts
@@ -1,0 +1,201 @@
+import { test, expect } from "@playwright/test";
+import { parseOracleQueryConstraints } from "../src/utils/naturalLanguageSort";
+import {
+  LOW_RATING_THRESHOLD,
+  buildTasteContextString,
+  buildUserTasteProfile,
+} from "../src/utils/oracleTasteProfile";
+import { resolveOracleQueryConstraints } from "../src/utils/oracleQueryConstraints";
+import {
+  ensureOracleRecommendationShape,
+  getOracleFailureBucket,
+  isAbortLikeError,
+  shouldRetryOracleError,
+} from "../src/utils/oracleReliability";
+
+test("Oracle query parser maps compound prompt constraints", async () => {
+  const parsed = parseOracleQueryConstraints("pre-1960 horror on my watchlist");
+
+  expect(parsed.hasConstraints).toBeTruthy();
+  expect(parsed.watchStatus).toBe("to-watch");
+  expect(parsed.yearMax).toBe(1959);
+  expect(parsed.genreIds).toContain(27);
+  expect(parsed.genreNames).toContain("horror");
+});
+
+test("Oracle query parser maps between-year constraints", async () => {
+  const parsed = parseOracleQueryConstraints("between 1980 and 1990 thriller movies");
+
+  expect(parsed.hasConstraints).toBeTruthy();
+  expect(parsed.yearMin).toBe(1980);
+  expect(parsed.yearMax).toBe(1990);
+  expect(parsed.genreNames).toContain("thriller");
+});
+
+test("Oracle taste profile includes weighted sections and rating polarity buckets", async () => {
+  const logs = [
+    {
+      title: "Recent Favorite",
+      watch_status: "watched",
+      rating: 4.8,
+      moods: ["moody"],
+      genres: ["drama"],
+      year: 2021,
+      created_at: new Date().toISOString(),
+    },
+    {
+      title: "Old Favorite",
+      watch_status: "watched",
+      rating: 4.4,
+      moods: ["moody"],
+      genres: ["drama"],
+      year: 2018,
+      created_at: "2024-01-01T00:00:00.000Z",
+    },
+    {
+      title: "Avoid Candidate",
+      watch_status: "watched",
+      rating: LOW_RATING_THRESHOLD,
+      moods: ["grim"],
+      genres: ["horror"],
+      year: 2016,
+      created_at: new Date().toISOString(),
+    },
+  ];
+  const recentToWatch = [{ title: "Next Up", created_at: new Date().toISOString() }];
+  const listItems = [{ title: "Curated Pick" }];
+
+  const profile = buildUserTasteProfile(logs, recentToWatch, listItems);
+  const context = buildTasteContextString(profile);
+
+  expect(profile.weightedSignals.moods[0].label).toBe("moody");
+  expect(profile.weightedSignals.genres[0].label).toBe("drama");
+  expect(profile.ratingBuckets.liked).toContain("Recent Favorite");
+  expect(profile.ratingBuckets.avoid).toContain("Avoid Candidate");
+  expect(context).toContain("MoodAffinityWeighted:");
+  expect(context).toContain("GenreAffinityWeighted:");
+  expect(context).toContain("AvoidSimilarTo: Avoid Candidate");
+});
+
+test("Oracle taste context preserves avoid-like titles under deterministic capping", async () => {
+  const logs = Array.from({ length: 40 }).map((_, index) => ({
+    title: `Low Rated ${index + 1}`,
+    watch_status: "watched",
+    rating: 1.5,
+    moods: ["tense"],
+    genres: ["thriller"],
+    year: 2000 + (index % 20),
+    created_at: new Date(Date.now() - index * 1000 * 60).toISOString(),
+  }));
+  const profile = buildUserTasteProfile(logs, [], []);
+  const context = buildTasteContextString(profile);
+
+  const avoidLine = context
+    .split("\n")
+    .find((line) => line.startsWith("AvoidSimilarTo:"));
+  expect(avoidLine).toBeTruthy();
+  expect(avoidLine).not.toContain("none");
+  expect((avoidLine?.split(",") || []).length).toBeLessThanOrEqual(10);
+});
+
+test("Oracle RPC-compatible payload keeps deterministic context line ordering", async () => {
+  const rpcLikeProfile = {
+    summary: {
+      watchedCount: 120,
+      recentWatchedCount: 12,
+      avgRating: "3.94",
+      topMoods: ["moody", "cozy"],
+      topGenres: ["drama", "thriller"],
+      topDecades: ["1990s", "2000s"],
+    },
+    weightedSignals: {
+      moods: [{ label: "moody", score: 2.34, count: 3 }],
+      genres: [{ label: "drama", score: 2.12, count: 3 }],
+    },
+    ratingBuckets: {
+      liked: ["Liked 1", "Liked 2", "Liked 3"],
+      avoid: ["Avoid 1", "Avoid 2"],
+      neutral: ["Neutral 1"],
+    },
+    recentWatchedTitles: ["Recent 1", "Recent 2"],
+    recentToWatchTitles: ["Watchlist 1"],
+    curatedTitles: ["Curated 1", "Curated 2"],
+  };
+
+  const contextLines = buildTasteContextString(rpcLikeProfile).split("\n");
+  expect(contextLines[0].startsWith("TasteStats:")).toBeTruthy();
+  expect(contextLines[1].startsWith("TopMoods:")).toBeTruthy();
+  expect(contextLines[2].startsWith("TopGenres:")).toBeTruthy();
+  expect(contextLines[3].startsWith("MoodAffinityWeighted:")).toBeTruthy();
+  expect(contextLines[4].startsWith("GenreAffinityWeighted:")).toBeTruthy();
+  expect(contextLines[7].startsWith("AvoidSimilarTo:")).toBeTruthy();
+});
+
+test("Oracle constraint resolver falls back to deterministic parser if Groq parser fails", async () => {
+  const constraints = await resolveOracleQueryConstraints("pre-1960 horror on my watchlist", {
+    constraintsEnabled: true,
+    groqIntentEnabled: true,
+    groqIntentParser: async () => {
+      throw new Error("Groq timeout");
+    },
+  });
+
+  expect(constraints.watchStatus).toBe("to-watch");
+  expect(constraints.yearMax).toBe(1959);
+  expect(constraints.genreIds).toContain(27);
+  expect(constraints.hasConstraints).toBeTruthy();
+});
+
+test("Oracle constraint resolver prefers Groq parser payload when valid", async () => {
+  const constraints = await resolveOracleQueryConstraints("anything", {
+    constraintsEnabled: true,
+    groqIntentEnabled: true,
+    groqIntentParser: async () => ({
+      normalizedText: "anything",
+      yearMin: 1980,
+      yearMax: 1990,
+      watchStatus: "watched",
+      genreIds: [53],
+      genreNames: ["thriller"],
+      hasConstraints: true,
+      strippedPrompt: "anything",
+    }),
+  });
+
+  expect(constraints.watchStatus).toBe("watched");
+  expect(constraints.yearMin).toBe(1980);
+  expect(constraints.yearMax).toBe(1990);
+  expect(constraints.genreIds).toEqual([53]);
+});
+
+test("Oracle reliability maps failure buckets deterministically", async () => {
+  expect(getOracleFailureBucket(new Error("request timeout while fetching"))).toBe("timeout");
+  expect(getOracleFailureBucket({ message: "Rate limit hit", status: 429 })).toBe("rate_limit");
+  expect(getOracleFailureBucket(new Error("JSON parse failed"))).toBe("parse_fail");
+  expect(getOracleFailureBucket({ message: "Upstream unavailable", status: 503 })).toBe("upstream_unavailable");
+});
+
+test("Oracle reliability retry policy skips 404 and retries transient failures", async () => {
+  expect(shouldRetryOracleError({ status: 404, message: "model not found" })).toBeFalsy();
+  expect(shouldRetryOracleError({ status: 429, message: "rate limited" })).toBeTruthy();
+  expect(shouldRetryOracleError({ status: 500, message: "upstream failure" })).toBeTruthy();
+  expect(shouldRetryOracleError({ message: "request timeout" })).toBeTruthy();
+});
+
+test("Oracle fallback payload normalizer guarantees UI-safe rationale and vibeCheck", async () => {
+  const normalized = ensureOracleRecommendationShape([
+    { title: "Fallback Title", year: "1999", rationale: "", vibeCheck: "" },
+    { title: "  ", year: null },
+  ]);
+  expect(normalized).toHaveLength(1);
+  expect(normalized[0].title).toBe("Fallback Title");
+  expect(normalized[0].year).toBe(1999);
+  expect(normalized[0].rationale.length).toBeGreaterThan(0);
+  expect(normalized[0].vibeCheck.length).toBeGreaterThan(0);
+});
+
+test("Oracle abort detection catches abort-like errors", async () => {
+  expect(isAbortLikeError({ name: "AbortError", message: "aborted" })).toBeTruthy();
+  expect(isAbortLikeError({ message: "Request cancelled by reroll" })).toBeTruthy();
+  expect(isAbortLikeError(new Error("Something else"))).toBeFalsy();
+});

--- a/tests/oracle-query-intelligence.spec.ts
+++ b/tests/oracle-query-intelligence.spec.ts
@@ -12,6 +12,8 @@ import {
   isAbortLikeError,
   shouldRetryOracleError,
 } from "../src/utils/oracleReliability";
+import { buildOracleEventPayload } from "../src/utils/oracleAnalytics";
+import { rankRecommendationsByProviderAffinity } from "../src/utils/oracleRanking";
 
 test("Oracle query parser maps compound prompt constraints", async () => {
   const parsed = parseOracleQueryConstraints("pre-1960 horror on my watchlist");
@@ -199,3 +201,183 @@ test("Oracle abort detection catches abort-like errors", async () => {
   expect(isAbortLikeError({ message: "Request cancelled by reroll" })).toBeTruthy();
   expect(isAbortLikeError(new Error("Something else"))).toBeFalsy();
 });
+
+test("Oracle analytics payload maps expanded telemetry metrics", async () => {
+  const payload = buildOracleEventPayload({
+    userId: "00000000-0000-0000-0000-000000000001",
+    meta: {
+      provider: "openrouter",
+      modelUsed: "google/gemini-2.0-flash-001",
+      groqUsed: true,
+      latency: "1420ms",
+      qualityMetrics: {
+        inputRecommendationCount: 7,
+        postFilterRecommendationCount: 4,
+        dedupeDroppedCount: 2,
+        rejectedViolationAttemptCount: 1,
+      },
+      attemptMetrics: {
+        providerAttemptCount: 2,
+        fallbackDepth: 1,
+        providerAttempts: [
+          {
+            provider: "gemini",
+            model: "gemini-2.0-flash",
+            result: "failure",
+            status: "429",
+            failure_bucket: "rate_limit",
+            latency_ms: 500,
+          },
+          {
+            provider: "openrouter",
+            model: "google/gemini-2.0-flash-001",
+            result: "success",
+            status: "ok",
+            failure_bucket: null,
+            latency_ms: 920,
+          },
+        ],
+      },
+    },
+    success: true,
+    requestSource: "discover",
+    promptType: "custom_prompt",
+    recommendationCount: 4,
+    tmdbHitCount: 4,
+  });
+
+  expect(payload.input_recommendation_count).toBe(7);
+  expect(payload.post_filter_recommendation_count).toBe(4);
+  expect(payload.dedupe_dropped_count).toBe(2);
+  expect(payload.rejected_violation_attempt_count).toBe(1);
+  expect(payload.provider_attempt_count).toBe(2);
+  expect(payload.fallback_depth).toBe(1);
+  expect(payload.provider_attempts).toHaveLength(2);
+  expect(payload.provider_attempts[0].provider).toBe("gemini");
+  expect(payload.selected_provider_ids).toEqual([]);
+  expect(payload.provider_match_count).toBe(0);
+});
+
+test("Oracle analytics payload normalizes provider-attempt trace shape", async () => {
+  const payload = buildOracleEventPayload({
+    userId: "00000000-0000-0000-0000-000000000001",
+    meta: {
+      provider: "tmdb",
+      attemptMetrics: {
+        providerAttemptCount: 3,
+        fallbackDepth: 2,
+        providerAttempts: [
+          { provider: "gemini", result: "failure", failure_bucket: "timeout", latency_ms: "300" },
+          { provider: "openrouter", result: "failure", failure_bucket: "rate_limit", latency_ms: 480 },
+          { provider: "tmdb", result: "success", status: "ok", latency_ms: "1000ms" },
+        ],
+      },
+    },
+    success: true,
+    requestSource: "discover",
+    promptType: "custom_prompt",
+    recommendationCount: 3,
+    tmdbHitCount: 3,
+  });
+
+  expect(payload.provider_attempt_count).toBe(3);
+  expect(payload.fallback_depth).toBe(2);
+  expect(payload.provider_attempts[0].latency_ms).toBe(300);
+  expect(payload.provider_attempts[2].provider).toBe("tmdb");
+  expect(payload.provider_attempts[2].result).toBe("success");
+});
+
+test("Oracle analytics payload remains backward compatible without telemetry block", async () => {
+  const payload = buildOracleEventPayload({
+    userId: "00000000-0000-0000-0000-000000000001",
+    meta: {
+      provider: "gemini",
+      modelUsed: "gemini-2.0-flash",
+      groqUsed: false,
+      latency: "900ms",
+    },
+    success: false,
+    errorCode: "gemini_error",
+    requestSource: "discover",
+    promptType: "custom_prompt",
+    recommendationCount: 0,
+    tmdbHitCount: 0,
+  });
+
+  expect(payload.provider).toBe("gemini");
+  expect(payload.latency_ms).toBe(900);
+  expect(payload.input_recommendation_count).toBeNull();
+  expect(payload.provider_attempt_count).toBeNull();
+  expect(payload.provider_attempts).toEqual([]);
+  expect(payload.provider_filtered_out_count).toBe(0);
+});
+
+test("Oracle analytics payload persists selected provider and ranking metrics", async () => {
+  const payload = buildOracleEventPayload({
+    userId: "00000000-0000-0000-0000-000000000001",
+    meta: {
+      provider: "gemini",
+      rankingMetrics: {
+        matchedRecommendationCount: 3,
+        filteredOutCount: 2,
+      },
+    },
+    selectedProviderIds: [8, 337, 8, 9],
+    success: true,
+    requestSource: "discover",
+    promptType: "custom_prompt",
+    recommendationCount: 5,
+    tmdbHitCount: 5,
+  });
+
+  expect(payload.selected_provider_ids).toEqual([8, 337, 9]);
+  expect(payload.provider_match_count).toBe(3);
+  expect(payload.provider_filtered_out_count).toBe(2);
+});
+
+test("Oracle provider-aware ranking promotes matches deterministically", async () => {
+  const ranked = rankRecommendationsByProviderAffinity({
+    recommendations: [
+      { title: "No Match First", year: 2000 },
+      { title: "Strong Match", year: 2001 },
+      { title: "Weak Match", year: 2002 },
+    ],
+    tmdbResults: [
+      { id: 1, provider_logos: [], vote_average: 8.1, vote_count: 200 },
+      {
+        id: 2,
+        provider_logos: [{ provider_id: 8 }, { provider_id: 337 }],
+        vote_average: 7.5,
+        vote_count: 150,
+      },
+      { id: 3, provider_logos: [{ provider_id: 8 }], vote_average: 8.8, vote_count: 500 },
+    ],
+    providerResults: [{}, {}, {}],
+    selectedProviderIds: [8, 337],
+  });
+
+  expect(ranked.recommendations.map((rec) => rec.title)).toEqual([
+    "Strong Match",
+    "Weak Match",
+    "No Match First",
+  ]);
+  expect(ranked.rankingMetrics.matchedRecommendationCount).toBe(2);
+  expect(ranked.rankingMetrics.filteredOutCount).toBe(1);
+  expect(ranked.rankingMetrics.reorderedCount).toBeGreaterThan(0);
+  expect(ranked.rankingMetrics.promotedFirstItem).toBeTruthy();
+});
+
+test("Oracle provider-aware ranking preserves order without preferences", async () => {
+  const ranked = rankRecommendationsByProviderAffinity({
+    recommendations: [{ title: "A" }, { title: "B" }, { title: "C" }],
+    tmdbResults: [{ id: 1 }, { id: 2 }, { id: 3 }],
+    providerResults: [{}, {}, {}],
+    selectedProviderIds: [],
+  });
+
+  expect(ranked.recommendations.map((rec) => rec.title)).toEqual(["A", "B", "C"]);
+  expect(ranked.rankingMetrics.reorderedCount).toBe(0);
+  expect(ranked.rankingMetrics.hasProviderPreferences).toBeFalsy();
+  expect(ranked.rankingMetrics.filteredOutCount).toBe(0);
+});
+


### PR DESCRIPTION
## Summary
- Kept Sprint B intelligence paths intact (get_oracle_taste_profile RPC-first + local fallback, Groq intent parser with deterministic fallback).
- Added Sprint C reliability hardening (provider timeouts/retries, abort-safe request lifecycle, deterministic failure bucketing/stage tags).
- Retained and expanded Oracle regression coverage, and synced roadmap/changelog entries for both sprints.

## Test plan
- [x] 
px playwright test tests/oracle-query-intelligence.spec.ts (55 passed)
- [ ] Manual smoke: discover
- [ ] Manual smoke: reroll one
- [ ] Manual smoke: reroll all
- [ ] Manual smoke: forced provider fallback (Gemini/OpenRouter failure path)
- [ ] Verify oracle_provider_events receives expected ailure_bucket values